### PR TITLE
breaking: factory improvements

### DIFF
--- a/examples/composable/component.html
+++ b/examples/composable/component.html
@@ -22,9 +22,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         messages: {
           en: {

--- a/examples/composable/component.html
+++ b/examples/composable/component.html
@@ -22,9 +22,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         messages: {
           en: {

--- a/examples/composable/datetime.html
+++ b/examples/composable/datetime.html
@@ -20,9 +20,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja-JP',
         messages: {
           'en-US': {

--- a/examples/composable/datetime.html
+++ b/examples/composable/datetime.html
@@ -20,9 +20,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja-JP',
         messages: {
           'en-US': {

--- a/examples/composable/fallback/basic.html
+++ b/examples/composable/fallback/basic.html
@@ -12,9 +12,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         fallbackLocales: ['en'],
         messages: {

--- a/examples/composable/fallback/basic.html
+++ b/examples/composable/fallback/basic.html
@@ -12,9 +12,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         fallbackLocales: ['en'],
         messages: {

--- a/examples/composable/fallback/default-format.html
+++ b/examples/composable/fallback/default-format.html
@@ -22,9 +22,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         fallbackLocales: ['en'],
         messages: {

--- a/examples/composable/fallback/default-format.html
+++ b/examples/composable/fallback/default-format.html
@@ -22,9 +22,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         fallbackLocales: ['en'],
         messages: {

--- a/examples/composable/fallback/format.html
+++ b/examples/composable/fallback/format.html
@@ -12,9 +12,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         fallbackFormat: true, // enable, fallback to locale message key
         messages: {

--- a/examples/composable/fallback/format.html
+++ b/examples/composable/fallback/format.html
@@ -12,9 +12,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         fallbackFormat: true, // enable, fallback to locale message key
         messages: {

--- a/examples/composable/fallback/option.html
+++ b/examples/composable/fallback/option.html
@@ -15,9 +15,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         fallbackLocales: ['en'],
         messages: {

--- a/examples/composable/fallback/option.html
+++ b/examples/composable/fallback/option.html
@@ -15,9 +15,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         fallbackLocales: ['en'],
         messages: {

--- a/examples/composable/fallback/suppress.html
+++ b/examples/composable/fallback/suppress.html
@@ -12,9 +12,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         fallbackLocales: ['en'],
         fallbackWarn: false, // warning off

--- a/examples/composable/fallback/suppress.html
+++ b/examples/composable/fallback/suppress.html
@@ -12,9 +12,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         fallbackLocales: ['en'],
         fallbackWarn: false, // warning off

--- a/examples/composable/formatting/list.html
+++ b/examples/composable/formatting/list.html
@@ -19,9 +19,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         messages: {
           en: {

--- a/examples/composable/formatting/list.html
+++ b/examples/composable/formatting/list.html
@@ -19,9 +19,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         messages: {
           en: {

--- a/examples/composable/formatting/named.html
+++ b/examples/composable/formatting/named.html
@@ -19,9 +19,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         messages: {
           en: {

--- a/examples/composable/formatting/named.html
+++ b/examples/composable/formatting/named.html
@@ -19,9 +19,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         messages: {
           en: {

--- a/examples/composable/formatting/ruby.html
+++ b/examples/composable/formatting/ruby.html
@@ -19,9 +19,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         messages: {
           en: {

--- a/examples/composable/formatting/ruby.html
+++ b/examples/composable/formatting/ruby.html
@@ -19,9 +19,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         messages: {
           en: {

--- a/examples/composable/global.html
+++ b/examples/composable/global.html
@@ -21,7 +21,7 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
       const Child = {
         template: `
@@ -35,7 +35,7 @@
         }
       }
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         messages: {
           en: {

--- a/examples/composable/global.html
+++ b/examples/composable/global.html
@@ -21,7 +21,7 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
       const Child = {
         template: `
@@ -35,7 +35,7 @@
         }
       }
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         messages: {
           en: {

--- a/examples/composable/missing/handler.html
+++ b/examples/composable/missing/handler.html
@@ -12,9 +12,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         fallbackLocales: ['en'],
         missing: (locale, key, instance) => {

--- a/examples/composable/missing/handler.html
+++ b/examples/composable/missing/handler.html
@@ -12,9 +12,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         fallbackLocales: ['en'],
         missing: (locale, key, instance) => {

--- a/examples/composable/missing/option.html
+++ b/examples/composable/missing/option.html
@@ -15,9 +15,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         fallbackLocales: ['en'],
         messages: {

--- a/examples/composable/missing/option.html
+++ b/examples/composable/missing/option.html
@@ -15,9 +15,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         fallbackLocales: ['en'],
         messages: {

--- a/examples/composable/missing/suppress.html
+++ b/examples/composable/missing/suppress.html
@@ -12,9 +12,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         fallbackLocales: ['en'],
         missingWarn: false, // warning off

--- a/examples/composable/missing/suppress.html
+++ b/examples/composable/missing/suppress.html
@@ -12,9 +12,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         fallbackLocales: ['en'],
         missingWarn: false, // warning off

--- a/examples/composable/number.html
+++ b/examples/composable/number.html
@@ -28,9 +28,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja-JP',
         messages: {
           'en-US': {

--- a/examples/composable/number.html
+++ b/examples/composable/number.html
@@ -28,9 +28,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja-JP',
         messages: {
           'en-US': {

--- a/examples/composable/plural/basic.html
+++ b/examples/composable/plural/basic.html
@@ -23,9 +23,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'en',
         messages: {
           en: {

--- a/examples/composable/plural/basic.html
+++ b/examples/composable/plural/basic.html
@@ -23,9 +23,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'en',
         messages: {
           en: {

--- a/examples/composable/plural/custom.html
+++ b/examples/composable/plural/custom.html
@@ -23,7 +23,7 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
       function customRule(choice, choicesLength, orgRule) {
         if (choice === 0) {
@@ -42,7 +42,7 @@
         return choicesLength < 4 ? 2 : 3
       }
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ru',
         pluralRules: {
           ru: customRule

--- a/examples/composable/plural/custom.html
+++ b/examples/composable/plural/custom.html
@@ -23,7 +23,7 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
       function customRule(choice, choicesLength, orgRule) {
         if (choice === 0) {
@@ -42,7 +42,7 @@
         return choicesLength < 4 ? 2 : 3
       }
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ru',
         pluralRules: {
           ru: customRule

--- a/examples/composable/started.html
+++ b/examples/composable/started.html
@@ -19,9 +19,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createComposer, useI18n } = VueI18n
+      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createComposer({
+      const i18n = createI18n({
         locale: 'ja',
         messages: {
           en: {

--- a/examples/composable/started.html
+++ b/examples/composable/started.html
@@ -19,9 +19,9 @@
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18nComposer, useI18n } = VueI18n
+      const { createComposer, useI18n } = VueI18n
 
-      const i18n = createI18nComposer({
+      const i18n = createComposer({
         locale: 'ja',
         messages: {
           en: {

--- a/examples/legacy/component.html
+++ b/examples/legacy/component.html
@@ -25,6 +25,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja',
         messages: {
           en: {

--- a/examples/legacy/datetime.html
+++ b/examples/legacy/datetime.html
@@ -23,6 +23,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja-JP',
         messages: {
           'en-US': {

--- a/examples/legacy/fallback/basic.html
+++ b/examples/legacy/fallback/basic.html
@@ -15,6 +15,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja',
         fallbackLocale: 'en',
         messages: {

--- a/examples/legacy/fallback/format.html
+++ b/examples/legacy/fallback/format.html
@@ -15,6 +15,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja',
         formatFallbackMessages: true, // enable, fallback to locale message key
         messages: {

--- a/examples/legacy/fallback/suppress.html
+++ b/examples/legacy/fallback/suppress.html
@@ -15,6 +15,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja',
         fallbackLocale: 'en',
         silentFallbackWarn: true, // warning off

--- a/examples/legacy/formatting/list.html
+++ b/examples/legacy/formatting/list.html
@@ -22,6 +22,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja',
         messages: {
           en: {

--- a/examples/legacy/formatting/named.html
+++ b/examples/legacy/formatting/named.html
@@ -22,6 +22,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja',
         messages: {
           en: {

--- a/examples/legacy/formatting/ruby.html
+++ b/examples/legacy/formatting/ruby.html
@@ -22,6 +22,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja',
         messages: {
           en: {

--- a/examples/legacy/global.html
+++ b/examples/legacy/global.html
@@ -33,6 +33,7 @@
       }
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja',
         messages: {
           en: {

--- a/examples/legacy/missing/handler.html
+++ b/examples/legacy/missing/handler.html
@@ -15,6 +15,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja',
         fallbackLocale: 'en',
         missing: (locale, key, instance) => {

--- a/examples/legacy/missing/suppress.html
+++ b/examples/legacy/missing/suppress.html
@@ -15,6 +15,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja',
         fallbackLocale: 'en',
         silentTranslationWarn: true, // warning off

--- a/examples/legacy/number.html
+++ b/examples/legacy/number.html
@@ -31,6 +31,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja-JP',
         messages: {
           'en-US': {

--- a/examples/legacy/plural/basic.html
+++ b/examples/legacy/plural/basic.html
@@ -26,6 +26,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'en',
         messages: {
           en: {

--- a/examples/legacy/plural/custom.html
+++ b/examples/legacy/plural/custom.html
@@ -43,6 +43,7 @@
       }
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ru',
         pluralizationRules: {
           ru: customRule

--- a/examples/legacy/started.html
+++ b/examples/legacy/started.html
@@ -22,6 +22,7 @@
       const { createI18n } = VueI18n
 
       const i18n = createI18n({
+        legacy: true,
         locale: 'ja',
         messages: {
           en: {

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -1,7 +1,7 @@
 /**
- *  I18n Composer
+ *  Composer
  *
- *  I18n Composer is offered composable API for Vue 3
+ *  Composer is offered composable API for Vue 3
  *  This module is offered new style vue-i18n API
  */
 
@@ -74,9 +74,9 @@ export type MissingHandler = (
 export type CustomBlocks = string[]
 
 /**
- *  I18n Composer Options
+ *  Composer Options
  */
-export type I18nComposerOptions = {
+export type ComposerOptions = {
   locale?: Locale
   fallbackLocales?: Locale[]
   messages?: LocaleMessages
@@ -91,13 +91,13 @@ export type I18nComposerOptions = {
   fallbackFormat?: boolean
   postTranslation?: PostTranslationHandler
   __i18n?: CustomBlocks // for custom blocks, and internal
-  _root?: I18nComposer // for internal
+  _root?: Composer // for internal
 }
 
 /**
- *  I18n Composer Interfaces
+ *  Composer Interfaces
  */
-export type I18nComposer = {
+export type Composer = {
   /**
    * properties
    */
@@ -166,7 +166,7 @@ function defineRuntimeMissingHandler(
 }
 
 function getLocaleMessages(
-  options: I18nComposerOptions,
+  options: ComposerOptions,
   locale: Locale
 ): LocaleMessages {
   const { messages, __i18n } = options
@@ -186,18 +186,18 @@ function getLocaleMessages(
 }
 
 /**
- * I18n Composer factory
+ * Composer
  *
  * @example
  * case: Global resource base localization
  * ```js
  * import { createApp } from 'vue'
- * import { createI18nComposer, useI18n } 'vue-i18n'
+ * import { createComposer, useI18n } 'vue-i18n'
  *
- * const i18n = createI18nComposer({
+ * const i18n = createComposer({
  *   locale: 'ja',
  *   messages: {
- *     en: { ... }
+ *     en: { ... },
  *     ja: { ... }
  *   }
  * })
@@ -212,9 +212,7 @@ function getLocaleMessages(
  * app.mount('#app')
  * ```
  */
-export function createI18nComposer(
-  options: I18nComposerOptions = {}
-): I18nComposer {
+export function createComposer(options: ComposerOptions = {}): Composer {
   const { _root } = options
 
   // reactivity states

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -7,6 +7,8 @@ import {
   ComponentOptions
 } from 'vue'
 import { Composer, ComposerOptions, createComposer } from './composer'
+import { createVueI18n, VueI18n, VueI18nOptions } from './legacy'
+import { isBoolean, generateSymbolID } from './utils'
 
 export const GlobalI18nSymbol: InjectionKey<Composer> = Symbol.for('vue-i18n')
 const providers: Map<
@@ -14,8 +16,79 @@ const providers: Map<
   InjectionKey<Composer>
 > = new Map()
 
-const generateSymbolID = (): string =>
-  `vue-i18n-${new Date().getUTCMilliseconds().toString()}`
+/**
+ *  I18n Options
+ *
+ *  This option is `createI18n` factory option
+ */
+export type I18nOptions = {
+  legacy?: boolean
+} & (ComposerOptions | VueI18nOptions)
+
+/**
+ * I18n factory
+ *
+ * @example
+ * case: for Composable API
+ * ```js
+ * import { createApp } from 'vue'
+ * import { createI18n, useI18n } from 'vue-i18n'
+ *
+ * // call with I18n option
+ * const i18n = createI18n({
+ *   locale: 'ja',
+ *   messages: {
+ *     en: { ... },
+ *     ja: { ... }
+ *   }
+ * })
+ *
+ * const App = {
+ *   setup() {
+ *     // ...
+ *     const { t } = useI18n({ ... })
+ *     return { ... , t }
+ *   }
+ * }
+ *
+ * const app = createApp(App)
+ *
+ * // install!
+ * app.use(i18n)
+ * app.mount('#app')
+ * ```
+ *
+ * @example
+ * case: for Legacy API
+ * ```js
+ * import { createApp } from 'vue'
+ * import { createI18n } from 'vue-i18n'
+ *
+ * // call with I18n option
+ * const i18n = createI18n({
+ *   legacy: true, // you must specify 'lagacy' option
+ *   locale: 'ja',
+ *   messages: {
+ *     en: { ... },
+ *     ja: { ... }
+ *   }
+ * })
+ *
+ * const App = {
+ *   // ...
+ * }
+ *
+ * const app = createApp(App)
+ *
+ * // install!
+ * app.use(i18n)
+ * app.mount('#app')
+ * ```
+ */
+export function createI18n(options: I18nOptions = {}): Composer | VueI18n {
+  const legacyMode = isBoolean(options.legacy) ? options.legacy : false
+  return legacyMode ? createVueI18n(options) : createComposer(options)
+}
 
 /**
  * Enable vue-i18n composable API

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,9 @@ export {
 export * from './runtime/types'
 export {
   MissingHandler,
-  I18nComposerOptions,
-  I18nComposer,
-  createI18nComposer
+  ComposerOptions,
+  Composer,
+  createComposer
 } from './composer'
 export { useI18n } from './use'
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-export const VERSION = __VERSION__
 export { Path, PathValue } from './path'
 export {
   Locale,
@@ -8,13 +7,7 @@ export {
   PostTranslationHandler
 } from './runtime'
 export * from './runtime/types'
-export {
-  MissingHandler,
-  ComposerOptions,
-  Composer,
-  createComposer
-} from './composer'
-export { useI18n } from './use'
+export { MissingHandler, ComposerOptions, Composer } from './composer'
 export {
   TranslateResult,
   Choice,
@@ -25,6 +18,7 @@ export {
   NumberFormatResult,
   Formatter,
   VueI18nOptions,
-  VueI18n,
-  createI18n
+  VueI18n
 } from './legacy'
+export { createI18n, useI18n } from './i18n'
+export const VERSION = __VERSION__

--- a/src/legacy.ts
+++ b/src/legacy.ts
@@ -31,9 +31,9 @@ import {
 import {
   MissingHandler,
   CustomBlocks,
-  I18nComposer,
-  I18nComposerOptions,
-  createI18nComposer
+  Composer,
+  ComposerOptions,
+  createComposer
 } from './composer'
 import {
   isString,
@@ -84,7 +84,7 @@ export type VueI18nOptions = {
   pluralizationRules?: PluralizationRules
   postTranslation?: PostTranslationHandler
   __i18n?: CustomBlocks // for custom blocks, and internal
-  _root?: I18nComposer // for internal
+  _root?: Composer // for internal
 }
 
 /**
@@ -159,9 +159,7 @@ export type VueI18n = {
 /**
  *  Convert to I18n Composer Options from VueI18n Options
  */
-function convertI18nComposerOptions(
-  options: VueI18nOptions
-): I18nComposerOptions {
+function convertComposerOptions(options: VueI18nOptions): ComposerOptions {
   const locale = isString(options.locale) ? options.locale : 'en-US'
   const fallbackLocales = isString(options.fallbackLocale)
     ? [options.fallbackLocale]
@@ -231,7 +229,7 @@ function convertI18nComposerOptions(
  *  This function is compatible with constructor of `VueI18n` class (offered with vue-i18n@8.x) like `new VueI18n(...)`.
  */
 export function createI18n(options: VueI18nOptions = {}): VueI18n {
-  const composer = createI18nComposer(convertI18nComposerOptions(options))
+  const composer = createComposer(convertComposerOptions(options))
 
   // defines VueI18n
   const i18n = {

--- a/src/legacy.ts
+++ b/src/legacy.ts
@@ -224,11 +224,11 @@ function convertComposerOptions(options: VueI18nOptions): ComposerOptions {
 }
 
 /**
- *  createI18n factory
+ *  createVueI18n factory
  *
  *  This function is compatible with constructor of `VueI18n` class (offered with vue-i18n@8.x) like `new VueI18n(...)`.
  */
-export function createI18n(options: VueI18nOptions = {}): VueI18n {
+export function createVueI18n(options: VueI18nOptions = {}): VueI18n {
   const composer = createComposer(convertComposerOptions(options))
 
   // defines VueI18n

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -1,7 +1,7 @@
 import { ComponentPublicInstance, ComponentOptions } from 'vue'
 import { Path } from './path'
 import { Locale } from './runtime/context'
-import { I18nComposer } from './composer'
+import { Composer } from './composer'
 import {
   VueI18n,
   createI18n,
@@ -44,7 +44,7 @@ type LegacyMixin = {
 // supports compatibility for vue-i18n legacy mixin
 export function getMixin(
   legacy: VueI18n,
-  composer: I18nComposer
+  composer: Composer
 ): ComponentOptions {
   return {
     beforeCreate(this: ComponentPublicInstance<LegacyMixin>) {

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -4,7 +4,7 @@ import { Locale } from './runtime/context'
 import { Composer } from './composer'
 import {
   VueI18n,
-  createI18n,
+  createVueI18n,
   VueI18nOptions,
   TranslateResult,
   DateTimeFormatResult,
@@ -57,9 +57,9 @@ export function getMixin(
           optionsI18n.__i18n = options.__i18n
         }
         optionsI18n._root = composer
-        this.$i18n = createI18n(optionsI18n)
+        this.$i18n = createVueI18n(optionsI18n)
       } else if (options.__i18n) {
-        this.$i18n = createI18n({ __i18n: options.__i18n, _root: composer })
+        this.$i18n = createVueI18n({ __i18n: options.__i18n, _root: composer })
       } else if (this.$root && this.$root.proxy) {
         // root i18n
         // TODO: should resolve type inference

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,10 +1,10 @@
 import { App, FunctionDirective } from 'vue'
-import { I18nComposer } from './composer'
+import { Composer } from './composer'
 import { GlobalI18nSymbol } from './use'
 import { Interpolate, Number } from './components'
 import { hook as vT } from './directive'
 
-export function apply(app: App, composer: I18nComposer): void {
+export function apply(app: App, composer: Composer): void {
   // install components
   app.component(Interpolate.name, Interpolate)
   app.component(Number.name, Number)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,6 @@
 import { App, FunctionDirective } from 'vue'
 import { Composer } from './composer'
-import { GlobalI18nSymbol } from './use'
+import { GlobalI18nSymbol } from './i18n'
 import { Interpolate, Number } from './components'
 import { hook as vT } from './directive'
 

--- a/src/use.ts
+++ b/src/use.ts
@@ -6,18 +6,12 @@ import {
   ComponentInternalInstance,
   ComponentOptions
 } from 'vue'
-import {
-  I18nComposer,
-  I18nComposerOptions,
-  createI18nComposer
-} from './composer'
+import { Composer, ComposerOptions, createComposer } from './composer'
 
-export const GlobalI18nSymbol: InjectionKey<I18nComposer> = Symbol.for(
-  'vue-i18n'
-)
+export const GlobalI18nSymbol: InjectionKey<Composer> = Symbol.for('vue-i18n')
 const providers: Map<
   ComponentInternalInstance,
-  InjectionKey<I18nComposer>
+  InjectionKey<Composer>
 > = new Map()
 
 const generateSymbolID = (): string =>
@@ -60,7 +54,7 @@ const generateSymbolID = (): string =>
  * </script>
  * ```
  */
-export function useI18n(options?: I18nComposerOptions): I18nComposer {
+export function useI18n(options?: ComposerOptions): Composer {
   const globalComposer = inject(GlobalI18nSymbol)
   if (!globalComposer) throw new Error('TODO') // TODO:
 
@@ -78,8 +72,8 @@ export function useI18n(options?: I18nComposerOptions): I18nComposer {
     if (globalComposer) {
       options._root = globalComposer
     }
-    const composer = createI18nComposer(options)
-    const sym: InjectionKey<I18nComposer> = Symbol.for(generateSymbolID())
+    const composer = createComposer(options)
+    const sym: InjectionKey<Composer> = Symbol.for(generateSymbolID())
     providers.set(instance, sym)
     provide(sym, composer)
     return composer

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,6 +39,9 @@ export const toDisplayString = (val: unknown): string => {
     : String(val)
 }
 
+export const generateSymbolID = (): string =>
+  `vue-i18n-${new Date().getUTCMilliseconds().toString()}`
+
 export function warn(msg: string, err?: Error): void {
   if (typeof console !== 'undefined') {
     console.warn('[vue-i18n] ' + msg)

--- a/test/composer.test.ts
+++ b/test/composer.test.ts
@@ -5,22 +5,22 @@ jest.mock('../src/utils', () => ({
 }))
 import { warn } from '../src/utils'
 
-import { createI18nComposer, MissingHandler } from '../src/composer'
+import { createComposer, MissingHandler } from '../src/composer'
 import { watch } from 'vue'
 
 describe('locale', () => {
   test('default value', () => {
-    const { locale } = createI18nComposer({})
+    const { locale } = createComposer({})
     expect(locale.value).toEqual('en-US')
   })
 
   test('initialize at composer creating', () => {
-    const { locale } = createI18nComposer({ locale: 'ja' })
+    const { locale } = createComposer({ locale: 'ja' })
     expect(locale.value).toEqual('ja')
   })
 
   test('reactivity', done => {
-    const { locale } = createI18nComposer({})
+    const { locale } = createComposer({})
     watch(locale, () => {
       expect(locale.value).toEqual('en')
       done()
@@ -31,24 +31,24 @@ describe('locale', () => {
 
 describe('fallbackLocales', () => {
   test('default value', () => {
-    const { fallbackLocales } = createI18nComposer({})
+    const { fallbackLocales } = createComposer({})
     expect(fallbackLocales.value).toEqual([])
   })
 
   test('initialize at composer creating', () => {
-    const { fallbackLocales } = createI18nComposer({ fallbackLocales: ['ja'] })
+    const { fallbackLocales } = createComposer({ fallbackLocales: ['ja'] })
     expect(fallbackLocales.value).toEqual(['ja'])
   })
 })
 
 describe('availableLocales', () => {
   test('not initialize messages at composer creating', () => {
-    const { availableLocales } = createI18nComposer({})
+    const { availableLocales } = createComposer({})
     expect(availableLocales).toEqual(['en-US'])
   })
 
   test('initialize messages at composer creating', () => {
-    const { availableLocales } = createI18nComposer({
+    const { availableLocales } = createComposer({
       messages: {
         en: {},
         ja: {},
@@ -62,14 +62,14 @@ describe('availableLocales', () => {
 
 describe('messages', () => {
   test('default value', () => {
-    const { messages } = createI18nComposer({})
+    const { messages } = createComposer({})
     expect(messages.value).toEqual({
       'en-US': {}
     })
   })
 
   test('initialize at composer creating', () => {
-    const { messages } = createI18nComposer({
+    const { messages } = createComposer({
       messages: {
         en: { hello: 'Hello,world!' },
         ja: {
@@ -98,14 +98,14 @@ describe('messages', () => {
 
 describe('datetimeFormats', () => {
   test('default value', () => {
-    const { datetimeFormats } = createI18nComposer({})
+    const { datetimeFormats } = createComposer({})
     expect(datetimeFormats.value).toEqual({
       'en-US': {}
     })
   })
 
   test('initialize at composer creating', () => {
-    const { datetimeFormats } = createI18nComposer({
+    const { datetimeFormats } = createComposer({
       datetimeFormats: {
         'en-US': {
           short: {
@@ -152,14 +152,14 @@ describe('datetimeFormats', () => {
 
 describe('numberFormats', () => {
   test('default value', () => {
-    const { numberFormats } = createI18nComposer({})
+    const { numberFormats } = createComposer({})
     expect(numberFormats.value).toEqual({
       'en-US': {}
     })
   })
 
   test('initialize at composer creating', () => {
-    const { numberFormats } = createI18nComposer({
+    const { numberFormats } = createComposer({
       numberFormats: {
         'en-US': {
           currency: {
@@ -198,7 +198,7 @@ describe('numberFormats', () => {
 
 describe('modifiers', () => {
   test('default', () => {
-    const { modifiers } = createI18nComposer({})
+    const { modifiers } = createComposer({})
     expect(modifiers).toEqual({})
   })
 
@@ -206,7 +206,7 @@ describe('modifiers', () => {
     const _modifiers = {
       kebab: (str: string) => str.replace(/\s+/g, '-').toLowerCase()
     }
-    const { modifiers, t } = createI18nComposer({
+    const { modifiers, t } = createComposer({
       locale: 'en',
       messages: {
         en: {
@@ -223,7 +223,7 @@ describe('modifiers', () => {
 
 describe('pluralRules', () => {
   test('default', () => {
-    const { pluralRules } = createI18nComposer({})
+    const { pluralRules } = createComposer({})
     expect(pluralRules).toBeUndefined()
   })
 
@@ -233,7 +233,7 @@ describe('pluralRules', () => {
         return 0
       }
     }
-    const { pluralRules } = createI18nComposer({
+    const { pluralRules } = createComposer({
       pluralRules: _pluralRules
     })
     expect(pluralRules).toEqual(_pluralRules)
@@ -242,46 +242,46 @@ describe('pluralRules', () => {
 
 describe('missingWarn', () => {
   test('default', () => {
-    const { missingWarn } = createI18nComposer({})
+    const { missingWarn } = createComposer({})
     expect(missingWarn).toEqual(true)
   })
 
   test('initialize at composer creating: boolean', () => {
-    const { missingWarn } = createI18nComposer({ missingWarn: false })
+    const { missingWarn } = createComposer({ missingWarn: false })
     expect(missingWarn).toEqual(false)
   })
 
   test('initialize at composer creating: regexp', () => {
-    const { missingWarn } = createI18nComposer({ missingWarn: /^(hi|hello)/ })
+    const { missingWarn } = createComposer({ missingWarn: /^(hi|hello)/ })
     expect(missingWarn).toEqual(/^(hi|hello)/)
   })
 })
 
 describe('fallbackWarn', () => {
   test('default', () => {
-    const { fallbackWarn } = createI18nComposer({})
+    const { fallbackWarn } = createComposer({})
     expect(fallbackWarn).toEqual(true)
   })
 
   test('initialize at composer creating: boolean', () => {
-    const { fallbackWarn } = createI18nComposer({ fallbackWarn: false })
+    const { fallbackWarn } = createComposer({ fallbackWarn: false })
     expect(fallbackWarn).toEqual(false)
   })
 
   test('initialize at composer creating: regexp', () => {
-    const { fallbackWarn } = createI18nComposer({ fallbackWarn: /^(hi|hello)/ })
+    const { fallbackWarn } = createComposer({ fallbackWarn: /^(hi|hello)/ })
     expect(fallbackWarn).toEqual(/^(hi|hello)/)
   })
 })
 
 describe('fallbackFormat', () => {
   test('default', () => {
-    const { fallbackFormat } = createI18nComposer({})
+    const { fallbackFormat } = createComposer({})
     expect(fallbackFormat).toEqual(false)
   })
 
   test('initialize at composer creating', () => {
-    const { fallbackFormat } = createI18nComposer({ fallbackFormat: true })
+    const { fallbackFormat } = createComposer({ fallbackFormat: true })
     expect(fallbackFormat).toEqual(true)
   })
 
@@ -289,7 +289,7 @@ describe('fallbackFormat', () => {
     const mockWarn = warn as jest.MockedFunction<typeof warn>
     mockWarn.mockImplementation(() => {}) // eslint-disable-line @typescript-eslint/no-empty-function
 
-    const { t } = createI18nComposer({
+    const { t } = createComposer({
       locale: 'en',
       fallbackLocales: ['ja', 'fr'],
       fallbackFormat: true,
@@ -311,7 +311,7 @@ describe('postTranslation', () => {
       getPostTranslationHandler,
       setPostTranslationHandler,
       t
-    } = createI18nComposer({
+    } = createComposer({
       locale: 'en',
       messages: {
         en: { hello: ' hello world! ' }
@@ -327,7 +327,7 @@ describe('postTranslation', () => {
 
   test('initialize at composer creating', () => {
     const handler = (str: string) => str.trim()
-    const { getPostTranslationHandler, t } = createI18nComposer({
+    const { getPostTranslationHandler, t } = createComposer({
       locale: 'en',
       messages: {
         en: { hello: ' hello world! ' }
@@ -341,7 +341,7 @@ describe('postTranslation', () => {
 
 describe('getMissingHandler / setMissingHandler', () => {
   test('default', () => {
-    const { getMissingHandler, setMissingHandler } = createI18nComposer({})
+    const { getMissingHandler, setMissingHandler } = createComposer({})
     expect(getMissingHandler()).toEqual(null)
 
     const missing = () => {} // eslint-disable-line @typescript-eslint/no-empty-function
@@ -351,14 +351,14 @@ describe('getMissingHandler / setMissingHandler', () => {
 
   test('initialize at composer creating', () => {
     const missing = () => {} // eslint-disable-line @typescript-eslint/no-empty-function
-    const { getMissingHandler } = createI18nComposer({ missing })
+    const { getMissingHandler } = createComposer({ missing })
     expect(getMissingHandler()).toEqual(missing)
   })
 })
 
 describe('t', () => {
   test('basic', () => {
-    const { t } = createI18nComposer({
+    const { t } = createComposer({
       locale: 'en',
       messages: {
         en: { hi: 'hi kazupon !' }
@@ -368,7 +368,7 @@ describe('t', () => {
   })
 
   test('list', () => {
-    const { t } = createI18nComposer({
+    const { t } = createComposer({
       locale: 'en',
       messages: {
         en: { hi: 'hi {0} !' }
@@ -378,7 +378,7 @@ describe('t', () => {
   })
 
   test('named', () => {
-    const { t } = createI18nComposer({
+    const { t } = createComposer({
       locale: 'en',
       messages: {
         en: { hi: 'hi {name} !' }
@@ -388,7 +388,7 @@ describe('t', () => {
   })
 
   test('linked', () => {
-    const { t } = createI18nComposer({
+    const { t } = createComposer({
       locale: 'en',
       messages: {
         en: {
@@ -401,7 +401,7 @@ describe('t', () => {
   })
 
   test('plural', () => {
-    const { t } = createI18nComposer({
+    const { t } = createComposer({
       locale: 'en',
       messages: {
         en: { apple: 'no apples | one apple | {count} apples' }
@@ -415,7 +415,7 @@ describe('t', () => {
 })
 
 test('d', () => {
-  const { d } = createI18nComposer({
+  const { d } = createComposer({
     locale: 'en-US',
     fallbackLocales: ['ja-JP'],
     datetimeFormats: {
@@ -457,7 +457,7 @@ test('d', () => {
 })
 
 test('n', () => {
-  const { n } = createI18nComposer({
+  const { n } = createComposer({
     locale: 'en-US',
     fallbackLocales: ['ja-JP'],
     numberFormats: {
@@ -497,7 +497,7 @@ describe('getLocaleMessage / setLocaleMessage / mergeLocaleMessage', () => {
       getLocaleMessage,
       setLocaleMessage,
       mergeLocaleMessage
-    } = createI18nComposer({
+    } = createComposer({
       messages: {
         en: { hello: 'Hello!' }
       }
@@ -521,7 +521,7 @@ describe('getDateTimeFormat / setDateTimeFormat / mergeDateTimeFormat', () => {
       getDateTimeFormat,
       setDateTimeFormat,
       mergeDateTimeFormat
-    } = createI18nComposer({
+    } = createComposer({
       datetimeFormats: {
         'en-US': {
           short: {
@@ -600,7 +600,7 @@ describe('getNumberFormat / setNumberFormat / mergeNumberFormat', () => {
       getNumberFormat,
       setNumberFormat,
       mergeNumberFormat
-    } = createI18nComposer({
+    } = createComposer({
       numberFormats: {
         'en-US': {
           currency: {
@@ -655,7 +655,7 @@ describe('getNumberFormat / setNumberFormat / mergeNumberFormat', () => {
 
 describe('__i18n', () => {
   test('default value', () => {
-    const { messages } = createI18nComposer({
+    const { messages } = createComposer({
       __i18n: [
         JSON.stringify({ en: { hello: 'Hello,world!' } }),
         JSON.stringify({

--- a/test/legacy.test.ts
+++ b/test/legacy.test.ts
@@ -5,24 +5,24 @@ jest.mock('../src/utils', () => ({
 }))
 import { warn } from '../src/utils'
 
-import { createI18n } from '../src/legacy'
+import { createVueI18n } from '../src/legacy'
 
 test('locale', () => {
-  const i18n = createI18n()
+  const i18n = createVueI18n()
   expect(i18n.locale).toEqual('en-US')
   i18n.locale = 'ja'
   expect(i18n.locale).toEqual('ja')
 })
 
 test('fallbackLocale', () => {
-  const i18n = createI18n()
+  const i18n = createVueI18n()
   expect(i18n.fallbackLocale).toEqual('en-US')
   i18n.fallbackLocale = 'ja'
   expect(i18n.fallbackLocale).toEqual('ja')
 })
 
 test('availableLocales', () => {
-  const i18n = createI18n({
+  const i18n = createVueI18n({
     messages: {
       en: {},
       ja: {},
@@ -37,7 +37,7 @@ test('formatter', () => {
   const mockWarn = warn as jest.MockedFunction<typeof warn>
   mockWarn.mockImplementation(() => {}) // eslint-disable-line @typescript-eslint/no-empty-function
 
-  const i18n = createI18n({
+  const i18n = createVueI18n({
     formatter: {
       interpolate() {
         return []
@@ -58,7 +58,7 @@ test('formatter', () => {
 })
 
 test('missing', () => {
-  const i18n = createI18n()
+  const i18n = createVueI18n()
   expect(i18n.missing).toEqual(null)
   const handler = () => {
     return ''
@@ -69,7 +69,7 @@ test('missing', () => {
 
 test('silentTranslationWarn', () => {
   // default
-  const i18n = createI18n()
+  const i18n = createVueI18n()
   expect(i18n.silentTranslationWarn).toEqual(false)
   i18n.silentTranslationWarn = true
   expect(i18n.silentTranslationWarn).toEqual(true)
@@ -77,13 +77,13 @@ test('silentTranslationWarn', () => {
   expect(i18n.silentTranslationWarn).toEqual(/^hi.*$/)
 
   // with option
-  const i18nWithOption = createI18n({ silentTranslationWarn: true })
+  const i18nWithOption = createVueI18n({ silentTranslationWarn: true })
   expect(i18nWithOption.silentTranslationWarn).toEqual(true)
 })
 
 test('silentFallbackWarn', () => {
   // default
-  const i18n = createI18n()
+  const i18n = createVueI18n()
   expect(i18n.silentFallbackWarn).toEqual(false)
   i18n.silentFallbackWarn = true
   expect(i18n.silentFallbackWarn).toEqual(true)
@@ -91,24 +91,24 @@ test('silentFallbackWarn', () => {
   expect(i18n.silentFallbackWarn).toEqual(/^hi.*$/)
 
   // with option
-  const i18nWithOption = createI18n({ silentFallbackWarn: true })
+  const i18nWithOption = createVueI18n({ silentFallbackWarn: true })
   expect(i18nWithOption.silentFallbackWarn).toEqual(true)
 })
 
 test('formatFallbackMessages', () => {
   // default
-  const i18n = createI18n()
+  const i18n = createVueI18n()
   expect(i18n.formatFallbackMessages).toEqual(false)
   i18n.formatFallbackMessages = true
   expect(i18n.formatFallbackMessages).toEqual(true)
 
   // withOption
-  const i18nWithOption = createI18n({ formatFallbackMessages: true })
+  const i18nWithOption = createVueI18n({ formatFallbackMessages: true })
   expect(i18nWithOption.formatFallbackMessages).toEqual(true)
 })
 
 test('postTranslation', () => {
-  const i18n = createI18n()
+  const i18n = createVueI18n()
   expect(i18n.postTranslation).toEqual(null)
   const postTranslation = (str: string) => str.trim()
   i18n.postTranslation = postTranslation
@@ -116,28 +116,28 @@ test('postTranslation', () => {
 })
 
 test('messages', () => {
-  const i18n = createI18n()
+  const i18n = createVueI18n()
   expect(i18n.messages).toEqual({
     'en-US': {}
   })
 })
 
 test('datetimeFormats', () => {
-  const i18n = createI18n()
+  const i18n = createVueI18n()
   expect(i18n.datetimeFormats).toEqual({
     'en-US': {}
   })
 })
 
 test('numberFormats', () => {
-  const i18n = createI18n()
+  const i18n = createVueI18n()
   expect(i18n.numberFormats).toEqual({
     'en-US': {}
   })
 })
 
 test('t', () => {
-  const i18n = createI18n({
+  const i18n = createVueI18n({
     locale: 'en',
     messages: {
       en: {
@@ -157,7 +157,7 @@ test('t', () => {
 })
 
 test('tc', () => {
-  const i18n = createI18n({
+  const i18n = createVueI18n({
     locale: 'en',
     messages: {
       en: {
@@ -170,7 +170,7 @@ test('tc', () => {
 })
 
 test('te', () => {
-  const i18n = createI18n({
+  const i18n = createVueI18n({
     locale: 'en',
     messages: {
       en: {
@@ -187,7 +187,7 @@ test('te', () => {
 })
 
 test('getLocaleMessage / setLocaleMessage / mergeLocaleMessage', () => {
-  const i18n = createI18n({
+  const i18n = createVueI18n({
     messages: {
       en: { hello: 'Hello!' }
     }
@@ -205,7 +205,7 @@ test('getLocaleMessage / setLocaleMessage / mergeLocaleMessage', () => {
 })
 
 test('d', () => {
-  const i18n = createI18n({
+  const i18n = createVueI18n({
     locale: 'en-US',
     fallbackLocale: 'ja-JP',
     datetimeFormats: {
@@ -245,7 +245,7 @@ test('d', () => {
 })
 
 test('n', () => {
-  const i18n = createI18n({
+  const i18n = createVueI18n({
     locale: 'en-US',
     fallbackLocale: 'ja-JP',
     numberFormats: {
@@ -280,7 +280,7 @@ test('n', () => {
 })
 
 test('getDateTimeFormat / setDateTimeFormat / mergeDateTimeFormat', () => {
-  const i18n = createI18n({
+  const i18n = createVueI18n({
     datetimeFormats: {
       'en-US': {
         short: {
@@ -353,7 +353,7 @@ test('getDateTimeFormat / setDateTimeFormat / mergeDateTimeFormat', () => {
 })
 
 test('getNumberFormat / setNumberFormat / mergeNumberFormat', () => {
-  const i18n = createI18n({
+  const i18n = createVueI18n({
     numberFormats: {
       'en-US': {
         currency: {
@@ -409,7 +409,7 @@ test('getChoiceIndex', () => {
   const mockWarn = warn as jest.MockedFunction<typeof warn>
   mockWarn.mockImplementation(() => {}) // eslint-disable-line @typescript-eslint/no-empty-function
 
-  const i18n = createI18n({})
+  const i18n = createVueI18n({})
   i18n.getChoiceIndex(1, 2)
   expect(mockWarn.mock.calls[0][0]).toEqual(
     `not supportted 'getChoiceIndex' method.`


### PR DESCRIPTION
- rename to `Composer` from `I18nComposer`
- organize factory function in one
  - `createI18n({ ... })` -> `createI18n({ legacy: true, ... })`
  - `createI18nComposer({ ... })` -> `createI18n({ ... })`