### PR TITLE
enhancement locale fallbacking

### DIFF
--- a/examples/composable/fallback/basic.html
+++ b/examples/composable/fallback/basic.html
@@ -16,7 +16,7 @@
 
       const i18n = createI18n({
         locale: 'ja',
-        fallbackLocales: ['en'],
+        fallbackLocale: ['en'],
         messages: {
           en: {
             message: {

--- a/examples/composable/fallback/default-format.html
+++ b/examples/composable/fallback/default-format.html
@@ -26,7 +26,7 @@
 
       const i18n = createI18n({
         locale: 'ja',
-        fallbackLocales: ['en'],
+        fallbackLocale: ['en'],
         messages: {
           en: {},
           ja: {}

--- a/examples/composable/fallback/option.html
+++ b/examples/composable/fallback/option.html
@@ -19,7 +19,7 @@
 
       const i18n = createI18n({
         locale: 'ja',
-        fallbackLocales: ['en'],
+        fallbackLocale: ['en'],
         messages: {
           en: {
             message: {

--- a/examples/composable/fallback/suppress.html
+++ b/examples/composable/fallback/suppress.html
@@ -16,7 +16,7 @@
 
       const i18n = createI18n({
         locale: 'ja',
-        fallbackLocales: ['en'],
+        fallbackLocale: ['en'],
         fallbackWarn: false, // warning off
         messages: {
           en: {

--- a/examples/composable/missing/handler.html
+++ b/examples/composable/missing/handler.html
@@ -16,7 +16,7 @@
 
       const i18n = createI18n({
         locale: 'ja',
-        fallbackLocales: ['en'],
+        fallbackLocale: ['en'],
         missing: (locale, key, instance) => {
           // something to do ...
           console.warn(`detect '${key}' key missing in '${locale}'`)

--- a/examples/composable/missing/option.html
+++ b/examples/composable/missing/option.html
@@ -19,7 +19,7 @@
 
       const i18n = createI18n({
         locale: 'ja',
-        fallbackLocales: ['en'],
+        fallbackLocale: ['en'],
         messages: {
           en: {
             message: {

--- a/examples/composable/missing/suppress.html
+++ b/examples/composable/missing/suppress.html
@@ -16,7 +16,7 @@
 
       const i18n = createI18n({
         locale: 'ja',
-        fallbackLocales: ['en'],
+        fallbackLocale: ['en'],
         missingWarn: false, // warning off
         messages: {
           en: {

--- a/src/legacy.ts
+++ b/src/legacy.ts
@@ -19,7 +19,8 @@ import {
   LocaleMessages,
   LocaleMessage,
   LocaleMessageDictionary,
-  PostTranslationHandler
+  PostTranslationHandler,
+  FallbackLocale
 } from './runtime/context'
 import { TranslateOptions } from './runtime/translate'
 import {
@@ -65,7 +66,7 @@ export interface Formatter {
  */
 export type VueI18nOptions = {
   locale?: Locale
-  fallbackLocale?: Locale
+  fallbackLocale?: FallbackLocale
   messages?: LocaleMessages
   datetimeFormats?: DateTimeFormats
   numberFormats?: NumberFormats
@@ -97,7 +98,7 @@ export type VueI18n = {
    * properties
    */
   locale: Locale
-  fallbackLocale: Locale
+  fallbackLocale: FallbackLocale
   readonly availableLocales: Locale[]
   readonly messages: LocaleMessages
   readonly datetimeFormats: DateTimeFormats
@@ -161,9 +162,13 @@ export type VueI18n = {
  */
 function convertComposerOptions(options: VueI18nOptions): ComposerOptions {
   const locale = isString(options.locale) ? options.locale : 'en-US'
-  const fallbackLocales = isString(options.fallbackLocale)
-    ? [options.fallbackLocale]
-    : []
+  const fallbackLocale =
+    isString(options.fallbackLocale) ||
+    isArray(options.fallbackLocale) ||
+    isPlainObject(options.fallbackLocale) ||
+    options.fallbackLocale === false
+      ? options.fallbackLocale
+      : locale
   const missing = isFunction(options.missing) ? options.missing : undefined
   const missingWarn =
     isBoolean(options.silentTranslationWarn) ||
@@ -207,7 +212,7 @@ function convertComposerOptions(options: VueI18nOptions): ComposerOptions {
 
   return {
     locale,
-    fallbackLocales,
+    fallbackLocale,
     messages,
     datetimeFormats,
     numberFormats,
@@ -246,13 +251,11 @@ export function createVueI18n(options: VueI18nOptions = {}): VueI18n {
     },
 
     // fallbackLocale
-    get fallbackLocale(): Locale {
-      return composer.fallbackLocales.value.length === 0
-        ? 'en-US' // compatible for vue-i18n legay style
-        : composer.fallbackLocales.value[0]
+    get fallbackLocale(): FallbackLocale {
+      return composer.fallbackLocale.value
     },
-    set fallbackLocale(val: Locale) {
-      composer.fallbackLocales.value = [val]
+    set fallbackLocale(val: FallbackLocale) {
+      composer.fallbackLocale.value = val
     },
 
     // messages

--- a/test/composer.test.ts
+++ b/test/composer.test.ts
@@ -29,15 +29,15 @@ describe('locale', () => {
   })
 })
 
-describe('fallbackLocales', () => {
+describe('fallbackLocale', () => {
   test('default value', () => {
-    const { fallbackLocales } = createComposer({})
-    expect(fallbackLocales.value).toEqual([])
+    const { fallbackLocale } = createComposer({})
+    expect(fallbackLocale.value).toEqual('en-US')
   })
 
   test('initialize at composer creating', () => {
-    const { fallbackLocales } = createComposer({ fallbackLocales: ['ja'] })
-    expect(fallbackLocales.value).toEqual(['ja'])
+    const { fallbackLocale } = createComposer({ fallbackLocale: ['ja'] })
+    expect(fallbackLocale.value).toEqual(['ja'])
   })
 })
 
@@ -291,7 +291,7 @@ describe('fallbackFormat', () => {
 
     const { t } = createComposer({
       locale: 'en',
-      fallbackLocales: ['ja', 'fr'],
+      fallbackLocale: ['ja', 'fr'],
       fallbackFormat: true,
       messages: {
         en: {},
@@ -417,7 +417,7 @@ describe('t', () => {
 test('d', () => {
   const { d } = createComposer({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
     datetimeFormats: {
       'en-US': {
         short: {
@@ -459,7 +459,7 @@ test('d', () => {
 test('n', () => {
   const { n } = createComposer({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
     numberFormats: {
       'en-US': {
         currency: {

--- a/test/runtime/context.test.ts
+++ b/test/runtime/context.test.ts
@@ -15,15 +15,20 @@ describe('locale', () => {
   })
 })
 
-describe('fallbackLocales', () => {
+describe('fallbackLocale', () => {
   test('default', () => {
     const ctx = context({})
-    expect(ctx.fallbackLocales).toEqual([])
+    expect(ctx.fallbackLocale).toEqual('en-US')
   })
 
-  test('specify', () => {
-    const ctx = context({ locale: 'en', fallbackLocales: ['ja'] })
-    expect(ctx.fallbackLocales).toEqual(['ja'])
+  test('default with locale', () => {
+    const ctx = context({ locale: 'en' })
+    expect(ctx.fallbackLocale).toEqual('en')
+  })
+
+  test('specify: fallbackLocale only', () => {
+    const ctx = context({ fallbackLocale: ['ja'] })
+    expect(ctx.fallbackLocale).toEqual(['ja'])
   })
 })
 
@@ -188,6 +193,10 @@ describe('getLocaleChain', () => {
   describe(`simple: 'en'`, () => {
     test('en', () => {
       expect(getLocaleChain(ctx, 'en', 'en')).toEqual(['en'])
+    })
+
+    test('ja', () => {
+      expect(getLocaleChain(ctx, 'en', 'ja')).toEqual(['ja', 'en'])
     })
 
     test('en-GB', () => {

--- a/test/runtime/context.test.ts
+++ b/test/runtime/context.test.ts
@@ -172,6 +172,10 @@ describe('getLocaleChain', () => {
       expect(getLocaleChain(ctx, false, 'en-GB')).toEqual(['en-GB', 'en'])
     })
 
+    test('en-GB!', () => {
+      expect(getLocaleChain(ctx, false, 'en-GB!')).toEqual(['en-GB'])
+    })
+
     test('de-DE-bavarian', () => {
       expect(getLocaleChain(ctx, false, 'de-DE-bavarian')).toEqual([
         'de-DE-bavarian',
@@ -188,6 +192,10 @@ describe('getLocaleChain', () => {
 
     test('en-GB', () => {
       expect(getLocaleChain(ctx, 'en', 'en-GB')).toEqual(['en-GB', 'en'])
+    })
+
+    test('en-GB!', () => {
+      expect(getLocaleChain(ctx, 'en', 'en-GB!')).toEqual(['en-GB', 'en'])
     })
 
     test('de-DE-bavarian', () => {
@@ -215,6 +223,14 @@ describe('getLocaleChain', () => {
 
     test('en-GB', () => {
       expect(getLocaleChain(ctx, ['en', 'ja'], 'en-GB')).toEqual([
+        'en-GB',
+        'en',
+        'ja'
+      ])
+    })
+
+    test('en-GB!', () => {
+      expect(getLocaleChain(ctx, ['en', 'ja'], 'en-GB!')).toEqual([
         'en-GB',
         'en',
         'ja'

--- a/test/runtime/context.test.ts
+++ b/test/runtime/context.test.ts
@@ -1,4 +1,7 @@
-import { createRuntimeContext as context } from '../../src/runtime/context'
+import {
+  createRuntimeContext as context,
+  getLocaleChain
+} from '../../src/runtime/context'
 
 describe('locale', () => {
   test('default', () => {
@@ -151,5 +154,206 @@ describe('postTranslation', () => {
     const hook = str => str
     const ctx = context({ postTranslation: hook })
     expect(ctx.postTranslation).toEqual(hook)
+  })
+})
+
+describe('getLocaleChain', () => {
+  let ctx
+  beforeEach(() => {
+    ctx = context({})
+  })
+
+  describe('none', () => {
+    test('en', () => {
+      expect(getLocaleChain(ctx, false, 'en')).toEqual(['en'])
+    })
+
+    test('en-GB', () => {
+      expect(getLocaleChain(ctx, false, 'en-GB')).toEqual(['en-GB', 'en'])
+    })
+
+    test('de-DE-bavarian', () => {
+      expect(getLocaleChain(ctx, false, 'de-DE-bavarian')).toEqual([
+        'de-DE-bavarian',
+        'de-DE',
+        'de'
+      ])
+    })
+  })
+
+  describe(`simple: 'en'`, () => {
+    test('en', () => {
+      expect(getLocaleChain(ctx, 'en', 'en')).toEqual(['en'])
+    })
+
+    test('en-GB', () => {
+      expect(getLocaleChain(ctx, 'en', 'en-GB')).toEqual(['en-GB', 'en'])
+    })
+
+    test('de-DE-bavarian', () => {
+      expect(getLocaleChain(ctx, 'en', 'de-DE-bavarian')).toEqual([
+        'de-DE-bavarian',
+        'de-DE',
+        'de',
+        'en'
+      ])
+    })
+
+    test('de', () => {
+      expect(getLocaleChain(ctx, 'en', 'de')).toEqual(['de', 'en'])
+    })
+
+    test('de-CH', () => {
+      expect(getLocaleChain(ctx, 'en', 'de-CH')).toEqual(['de-CH', 'de', 'en'])
+    })
+  })
+
+  describe(`array: ['en', 'ja']`, () => {
+    test('en', () => {
+      expect(getLocaleChain(ctx, ['en', 'ja'], 'en')).toEqual(['en', 'ja'])
+    })
+
+    test('en-GB', () => {
+      expect(getLocaleChain(ctx, ['en', 'ja'], 'en-GB')).toEqual([
+        'en-GB',
+        'en',
+        'ja'
+      ])
+    })
+
+    test('de-DE-bavarian', () => {
+      expect(getLocaleChain(ctx, ['en', 'ja'], 'de-DE-bavarian')).toEqual([
+        'de-DE-bavarian',
+        'de-DE',
+        'de',
+        'en',
+        'ja'
+      ])
+    })
+
+    test('de', () => {
+      expect(getLocaleChain(ctx, ['en', 'ja'], 'de')).toEqual([
+        'de',
+        'en',
+        'ja'
+      ])
+    })
+
+    test('de-CH', () => {
+      expect(getLocaleChain(ctx, ['en', 'ja'], 'de-CH')).toEqual([
+        'de-CH',
+        'de',
+        'en',
+        'ja'
+      ])
+    })
+  })
+
+  describe('complex', () => {
+    const fallbackLocale = {
+      'de-CH': ['fr', 'it'],
+      'zh-Hant': ['zh-Hans'],
+      'es-CL': ['es-AR'],
+      es: ['en-GB'],
+      pt: ['es-AR'],
+      default: ['en', 'da']
+    }
+
+    test('de-CH', () => {
+      expect(getLocaleChain(ctx, fallbackLocale, 'de-CH')).toEqual([
+        'de-CH',
+        'fr',
+        'it',
+        'en',
+        'da'
+      ])
+    })
+
+    test('de-CH!', () => {
+      expect(getLocaleChain(ctx, fallbackLocale, 'de-CH!')).toEqual([
+        'de-CH',
+        'fr',
+        'it',
+        'en',
+        'da'
+      ])
+    })
+
+    test('de-DE-bavarian', () => {
+      expect(getLocaleChain(ctx, fallbackLocale, 'de-DE-bavarian')).toEqual([
+        'de-DE-bavarian',
+        'de-DE',
+        'de',
+        'en',
+        'da'
+      ])
+    })
+
+    test('de', () => {
+      expect(getLocaleChain(ctx, fallbackLocale, 'de')).toEqual([
+        'de',
+        'en',
+        'da'
+      ])
+    })
+
+    test('zh-Hant', () => {
+      expect(getLocaleChain(ctx, fallbackLocale, 'zh-Hant')).toEqual([
+        'zh-Hant',
+        'zh-Hans',
+        'zh',
+        'en',
+        'da'
+      ])
+    })
+
+    test('es-SP', () => {
+      expect(getLocaleChain(ctx, fallbackLocale, 'es-SP')).toEqual([
+        'es-SP',
+        'es',
+        'en-GB',
+        'en',
+        'da'
+      ])
+    })
+
+    test('es-SP!', () => {
+      expect(getLocaleChain(ctx, fallbackLocale, 'es-SP!')).toEqual([
+        'es-SP',
+        'en',
+        'da'
+      ])
+    })
+
+    test('fr', () => {
+      expect(getLocaleChain(ctx, fallbackLocale, 'fr')).toEqual([
+        'fr',
+        'en',
+        'da'
+      ])
+    })
+
+    test('pt-BR', () => {
+      expect(getLocaleChain(ctx, fallbackLocale, 'pt-BR')).toEqual([
+        'pt-BR',
+        'pt',
+        'es-AR',
+        'es',
+        'en-GB',
+        'en',
+        'da'
+      ])
+    })
+
+    test('es-CL', () => {
+      expect(getLocaleChain(ctx, fallbackLocale, 'es-CL')).toEqual([
+        'es-CL',
+        'es-AR',
+        'es',
+        'en-GB',
+        'en',
+        'da'
+      ])
+    })
   })
 })

--- a/test/runtime/datetime.test.ts
+++ b/test/runtime/datetime.test.ts
@@ -63,7 +63,7 @@ test('datetime value', () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
     datetimeFormats
   })
 
@@ -78,7 +78,7 @@ test('number value', () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
     datetimeFormats
   })
 
@@ -93,7 +93,7 @@ test('key argument', () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
     datetimeFormats
   })
 
@@ -108,7 +108,7 @@ test('locale argument', () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
     datetimeFormats
   })
 
@@ -123,7 +123,7 @@ test('with object argument', () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
     datetimeFormats
   })
 
@@ -142,12 +142,17 @@ test('fallback', () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
+    missingWarn: false,
     datetimeFormats
   })
 
   expect(datetime(ctx, dt, 'long')).toEqual('2012/12/20 12:00:00')
+  expect(mockWarn).toHaveBeenCalledTimes(2)
   expect(mockWarn.mock.calls[0][0]).toEqual(
+    `Fall back to datetime format 'long' key with 'en' locale.`
+  )
+  expect(mockWarn.mock.calls[1][0]).toEqual(
     `Fall back to datetime format 'long' key with 'ja-JP' locale.`
   )
 })
@@ -162,8 +167,9 @@ test(`context fallbackWarn 'false' option`, () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
     fallbackWarn: false,
+    missingWarn: false,
     datetimeFormats
   })
 
@@ -181,7 +187,8 @@ test(`datetime function fallbackWarn 'false' option`, () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
+    missingWarn: false,
     datetimeFormats
   })
 
@@ -203,6 +210,7 @@ describe('context unresolving option', () => {
     const ctx = context({
       locale: 'en-US',
       fallbackWarn: false,
+      missingWarn: false,
       unresolving: true,
       datetimeFormats
     })
@@ -221,8 +229,9 @@ describe('context unresolving option', () => {
 
     const ctx = context({
       locale: 'en-US',
-      fallbackLocales: ['ja-JP'],
+      fallbackLocale: ['ja-JP'],
       fallbackWarn: false,
+      missingWarn: false,
       unresolving: true,
       datetimeFormats
     })
@@ -242,7 +251,7 @@ test('not available Intl API', () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
     datetimeFormats
   })
 

--- a/test/runtime/number.test.ts
+++ b/test/runtime/number.test.ts
@@ -118,12 +118,17 @@ test('fallback', () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
+    missingWarn: false,
     numberFormats
   })
 
   expect(number(ctx, 0.99, 'percent')).toEqual('99%')
+  expect(mockWarn).toHaveBeenCalledTimes(2)
   expect(mockWarn.mock.calls[0][0]).toEqual(
+    `Fall back to number format 'percent' key with 'en' locale.`
+  )
+  expect(mockWarn.mock.calls[1][0]).toEqual(
     `Fall back to number format 'percent' key with 'ja-JP' locale.`
   )
 })
@@ -138,7 +143,8 @@ test(`context fallbackWarn 'false' option`, () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
+    missingWarn: false,
     fallbackWarn: false,
     numberFormats
   })
@@ -157,7 +163,8 @@ test(`number function fallbackWarn 'false' option`, () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
+    missingWarn: false,
     numberFormats
   })
 
@@ -178,6 +185,7 @@ describe('context unresolving option', () => {
 
     const ctx = context({
       locale: 'en-US',
+      missingWarn: false,
       fallbackWarn: false,
       unresolving: true,
       numberFormats
@@ -197,7 +205,8 @@ describe('context unresolving option', () => {
 
     const ctx = context({
       locale: 'en-US',
-      fallbackLocales: ['ja-JP'],
+      fallbackLocale: ['ja-JP'],
+      missingWarn: false,
       fallbackWarn: false,
       unresolving: true,
       numberFormats
@@ -218,7 +227,7 @@ test('not available Intl API', () => {
 
   const ctx = context({
     locale: 'en-US',
-    fallbackLocales: ['ja-JP'],
+    fallbackLocale: ['ja-JP'],
     numberFormats
   })
 

--- a/test/runtime/translate.test.ts
+++ b/test/runtime/translate.test.ts
@@ -111,7 +111,7 @@ describe('default option', () => {
 })
 
 describe('context missing option', () => {
-  test('missing handler is nothing', () => {
+  test('not specified missing handler', () => {
     const mockWarn = warn as jest.MockedFunction<typeof warn>
     mockWarn.mockImplementation(() => {}) // eslint-disable-line @typescript-eslint/no-empty-function
 
@@ -128,39 +128,10 @@ describe('context missing option', () => {
     )
   })
 
-  test('missing handler that return string value', () => {
-    const ctx = context({
-      locale: 'en',
-      missing: (c, locale, key) => {
-        expect(c).toEqual(ctx)
-        expect(locale).toEqual('en')
-        expect(key).toEqual('hello')
-        return 'HELLO'
-      },
-      messages: {
-        en: {}
-      }
-    })
-    expect(translate(ctx, 'hello')).toEqual('HELLO')
-  })
+  test('specified missing handler', () => {
+    const mockWarn = warn as jest.MockedFunction<typeof warn>
+    mockWarn.mockImplementation(() => {}) // eslint-disable-line @typescript-eslint/no-empty-function
 
-  test('missing handler that return not string value', () => {
-    const ctx = context({
-      locale: 'en',
-      missing: (c, locale, key) => {
-        expect(c).toEqual(ctx)
-        expect(locale).toEqual('en')
-        expect(key).toEqual('hello')
-        return {} as string
-      },
-      messages: {
-        en: {}
-      }
-    })
-    expect(translate(ctx, 'hello')).toEqual('hello')
-  })
-
-  test('missing handler that not return value', () => {
     const ctx = context({
       locale: 'en',
       missing: (c, locale, key) => {
@@ -173,6 +144,7 @@ describe('context missing option', () => {
       }
     })
     expect(translate(ctx, 'hello')).toEqual('hello')
+    expect(mockWarn).not.toHaveBeenCalled()
   })
 })
 
@@ -210,6 +182,9 @@ describe('context missingWarn option', () => {
     expect(translate(ctx, 'hi kazupon!')).toEqual('hi kazupon!')
     expect(translate(ctx, 'hello')).toEqual('hello')
     expect(mockWarn).toHaveBeenCalledTimes(1)
+    expect(mockWarn.mock.calls[0][0]).not.toEqual(
+      `Not found 'hello' key in 'en' locale messages.`
+    )
   })
 
   test('missingWarn option', () => {
@@ -230,7 +205,7 @@ describe('context missingWarn option', () => {
 })
 
 describe('context fallbackWarn option', () => {
-  test('not specify fallbackLocales', () => {
+  test('not specify fallbackLocale', () => {
     const mockWarn = warn as jest.MockedFunction<typeof warn>
     mockWarn.mockImplementation(() => {}) // eslint-disable-line @typescript-eslint/no-empty-function
 
@@ -246,13 +221,13 @@ describe('context fallbackWarn option', () => {
     expect(mockWarn).not.toHaveBeenCalled()
   })
 
-  test('specify fallbackLocales', () => {
+  test('specify fallbackLocale', () => {
     const mockWarn = warn as jest.MockedFunction<typeof warn>
     mockWarn.mockImplementation(() => {}) // eslint-disable-line @typescript-eslint/no-empty-function
 
     const ctx = context({
       locale: 'en',
-      fallbackLocales: ['ja'],
+      fallbackLocale: ['ja'],
       missingWarn: false,
       messages: {
         en: {},
@@ -275,7 +250,7 @@ describe('context fallbackWarn option', () => {
 
     const ctx = context({
       locale: 'en',
-      fallbackLocales: ['ja', 'fr'],
+      fallbackLocale: ['ja', 'fr'],
       missingWarn: false,
       messages: {
         en: {},
@@ -286,7 +261,7 @@ describe('context fallbackWarn option', () => {
     expect(translate(ctx, 'hello.world')).toEqual('hello.world')
     expect(mockWarn).toHaveBeenCalledTimes(2)
     expect(mockWarn.mock.calls[0][0]).toEqual(
-      `Fall back to translate 'hello.world' key with 'ja,fr' locale.`
+      `Fall back to translate 'hello.world' key with 'ja' locale.`
     )
     expect(mockWarn.mock.calls[1][0]).toEqual(
       `Fall back to translate 'hello.world' key with 'fr' locale.`
@@ -299,7 +274,7 @@ describe('context fallbackWarn option', () => {
 
     const ctx = context({
       locale: 'en',
-      fallbackLocales: ['ja', 'fr'],
+      fallbackLocale: ['ja', 'fr'],
       missingWarn: false,
       fallbackWarn: false,
       messages: {
@@ -318,7 +293,7 @@ describe('context fallbackWarn option', () => {
 
     const ctx = context({
       locale: 'en',
-      fallbackLocales: ['ja', 'fr'],
+      fallbackLocale: ['ja', 'fr'],
       missingWarn: false,
       fallbackWarn: /^hello/,
       messages: {
@@ -337,7 +312,7 @@ describe('context fallbackWarn option', () => {
 
     const ctx = context({
       locale: 'en',
-      fallbackLocales: ['ja'],
+      fallbackLocale: ['ja'],
       missingWarn: false,
       messages: {
         en: {},
@@ -360,7 +335,7 @@ describe('context fallbackFormat option', () => {
 
     const ctx = context({
       locale: 'en',
-      fallbackLocales: ['ja', 'fr'],
+      fallbackLocale: ['ja', 'fr'],
       fallbackFormat: true,
       messages: {
         en: {},
@@ -377,7 +352,7 @@ describe('context fallbackFormat option', () => {
       `Not found 'hi, {name}!' key in 'en' locale messages.`
     )
     expect(mockWarn.mock.calls[1][0]).toEqual(
-      `Fall back to translate 'hi, {name}!' key with 'ja,fr' locale.`
+      `Fall back to translate 'hi, {name}!' key with 'ja' locale.`
     )
     expect(mockWarn.mock.calls[2][0]).toEqual(
       `Not found 'hi, {name}!' key in 'ja' locale messages.`
@@ -396,7 +371,7 @@ describe('context fallbackFormat option', () => {
 
     const ctx = context({
       locale: 'en',
-      fallbackLocales: ['ja', 'fr'],
+      fallbackLocale: ['ja', 'fr'],
       fallbackFormat: true,
       messages: {
         en: {},
@@ -413,7 +388,7 @@ describe('context fallbackFormat option', () => {
       `Not found 'hi, {name}!' key in 'en' locale messages.`
     )
     expect(mockWarn.mock.calls[1][0]).toEqual(
-      `Fall back to translate 'hi, {name}!' key with 'ja,fr' locale.`
+      `Fall back to translate 'hi, {name}!' key with 'ja' locale.`
     )
     expect(mockWarn.mock.calls[2][0]).toEqual(
       `Not found 'hi, {name}!' key in 'ja' locale messages.`
@@ -452,7 +427,7 @@ describe('context unresolving option', () => {
   test('fallbackWarn is truth', () => {
     const ctx = context({
       locale: 'en',
-      fallbackLocales: ['ja', 'fr'],
+      fallbackLocale: ['ja', 'fr'],
       missingWarn: false,
       fallbackWarn: /^hello/,
       unresolving: true,
@@ -467,7 +442,7 @@ describe('context unresolving option', () => {
   test('fallbackWarn is false', () => {
     const ctx = context({
       locale: 'en',
-      fallbackLocales: ['ja', 'fr'],
+      fallbackLocale: ['ja', 'fr'],
       missingWarn: false,
       fallbackWarn: false,
       unresolving: true,
@@ -485,7 +460,7 @@ describe('context unresolving option', () => {
 
     const ctx = context({
       locale: 'en',
-      fallbackLocales: ['ja', 'fr'],
+      fallbackLocale: ['ja', 'fr'],
       fallbackFormat: true,
       unresolving: true,
       messages: {


### PR DESCRIPTION
## enhancement `fallbackLocale` property (both legacy and composable APIs)
- automatic implicit fallback on locales with territory and dialects
- without explicit fallback (`false`)
- array of fallback locales
- decision map with fallbacks as described

related: https://github.com/kazupon/vue-i18n/pull/829

## breaking change
- remove `fallbackLocales` property of comoposr