### PR TITLE
refactor: simplify scope cases

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -371,15 +371,14 @@ export function useI18n<
 
   const global = i18n.global
 
-  let emptyOption = false
   // prettier-ignore
-  const scope: I18nScope = (emptyOption = isEmptyObject(options)) // eslint-disable-line no-cond-assign
+  const scope: I18nScope = isEmptyObject(options)
     ? 'global'
     : !options.useScope
       ? 'local'
       : options.useScope
 
-  if (emptyOption) {
+  if (scope === 'global') {
     return global
   }
 
@@ -398,8 +397,6 @@ export function useI18n<
       composer = global
     }
     return composer
-  } else if (scope === 'global') {
-    return global
   }
 
   // scope 'local' case


### PR DESCRIPTION
- When `emptyOption` is `true`, `scope` is always `global`
- When `scope` is `global`, we do not need to call `getCurrentInstance`, so it's better to return earlier than `getCurrentInstance()`

---

BTW, the following snippet might not be necessary:

```ts
  if (instance == null) {
    throw createI18nError(I18nErrorCodes.UNEXPECTED_ERROR)
  }
```

Becasue if the currentInstance is not available, the `inject()` api will return `undefined` and an error has already been thrown:

```ts
  const i18n = inject(I18nSymbol) as I18n<
    Messages,
    DateTimeFormats,
    NumberFormats
  >
  if (!i18n) {
    throw createI18nError(I18nErrorCodes.NOT_INSLALLED)
  }
```