### PR TITLE
Fix devtools typo

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -170,7 +170,7 @@ function createReplacePlugin(
     __NODE_JS__: isNodeBuild,
     // feature flags
     __FEATURE_PROD_DEVTOOLS__: isBundlerESMBuild
-      ? `__INTLFY_PROD_DEVTOOLS__`
+      ? `__INTLIFY_PROD_DEVTOOLS__`
       : false,
     ...(isProduction && isBrowserBuild
       ? {


### PR DESCRIPTION
This global var doesn't match it's definition (due to missing `I`) which causes the entire vite (esm) production build to fail with:

```
ReferenceError: __INTLFY_PROD_DEVTOOLS__ is not defined
``` 

fallback defined in `mist.ts`:

``` 
  if (typeof __FEATURE_PROD_DEVTOOLS__ !== 'boolean') {
    needWarn = true
    getGlobalThis().__INTLIFY_PROD_DEVTOOLS__ = false
  }
``` 