### PR TITLE
feat: global props and methods injection for composable mode

### DIFF
--- a/examples/composable/scope/global.html
+++ b/examples/composable/scope/global.html
@@ -10,18 +10,18 @@
     <div id="app">
       <h1>Root</h1>
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label>{{ $t('message.language') }}</label>
+        <select v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>
       </form>
-      <p>{{ t('message.hello') }}</p>
+      <p>{{ $t('message.hello') }}</p>
       <Child />
     </div>
     <script>
       const { createApp } = Vue
-      const { createI18n, useI18n } = VueI18n
+      const { createI18n } = VueI18n
 
       const SlotChild = {
         template: `
@@ -34,18 +34,15 @@
           <div class="sub-child">
             <h1>Sub Child</h1>
             <form>
-              <label>{{ t('message.language') }}</label>
-              <select v-model="locale">
+              <label>{{ $t('message.language') }}</label>
+              <select v-model="$i18n.locale">
                 <option value="en">en</option>
                 <option value="ja">ja</option>
               </select>
             </form>
-            <p>{{ t('message.hi') }}</p>
+            <p>{{ $t('message.hi') }}</p>
           </div>
-        `,
-        setup() {
-          return useI18n()
-        }
+        `
       }
 
       const Child = {
@@ -57,27 +54,24 @@
           <div class="child">
             <h1>Child</h1>
             <form>
-              <label>{{ t('message.language') }}</label>
-              <select v-model="locale">
+              <label>{{ $t('message.language') }}</label>
+              <select v-model="$i18n.locale">
                 <option value="en">en</option>
                 <option value="ja">ja</option>
               </select>
             </form>
-            <p>{{ t('message.hi') }}</p>
+            <p>{{ $t('message.hi') }}</p>
             <SubChild />
             t inside of slot
             <SlotChild>
-              {{ t('message.hi') }}
+              {{ $t('message.hi') }}
             </SlotChild>
             i18n-t inside of slot
             <SlotChild>
               <i18n-t keypath='message.hi'/>
             </SlotChild>
           </div>
-        `,
-        setup() {
-          return useI18n()
-        }
+        `
       }
 
       const i18n = createI18n({
@@ -101,10 +95,7 @@
       })
 
       const app = createApp({
-        components: { Child },
-        setup() {
-          return useI18n()
-        }
+        components: { Child }
       })
       app.use(i18n)
       app.mount('#app')

--- a/examples/composable/scope/inherit-locale.html
+++ b/examples/composable/scope/inherit-locale.html
@@ -10,13 +10,13 @@
     <div id="app">
       <h1>Root</h1>
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label>{{ $t('message.language') }}</label>
+        <select v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>
       </form>
-      <p>{{ t("message.hello") }}</p>
+      <p>{{ $t("message.hello") }}</p>
       <Child />
     </div>
     <script>
@@ -86,10 +86,7 @@
       })
 
       const app = createApp({
-        components: { Child },
-        setup() {
-          return useI18n()
-        }
+        components: { Child }
       })
       app.use(i18n)
       app.mount('#app')

--- a/examples/composable/scope/local.html
+++ b/examples/composable/scope/local.html
@@ -10,13 +10,13 @@
     <div id="app">
       <h1>Root</h1>
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label>{{ $t('message.language') }}</label>
+        <select v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>
       </form>
-      <p>{{ t("message.hello") }}</p>
+      <p>{{ $t("message.hello") }}</p>
       <Child />
     </div>
     <script>
@@ -81,10 +81,7 @@
       })
 
       const app = createApp({
-        components: { Child },
-        setup() {
-          return useI18n()
-        }
+        components: { Child }
       })
       app.use(i18n)
       app.mount('#app')

--- a/examples/composable/started.html
+++ b/examples/composable/started.html
@@ -41,6 +41,7 @@
 
       const app = createApp({
         setup() {
+          // `useI18n` return the global compser that is created at `createI18n`
           return useI18n()
         }
       })

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "benchmark": "yarn build && node ./benchmark/index.js",
     "build": "node ./scripts/build.js",
     "build:sourcemap": "yarn build --sourcemap",
-    "build:type": "yarn build --types && tail -n +11 src/vue.d.ts >> ./dist/vue-i18n.d.ts",
+    "build:type": "yarn build --types && tail -n +13 src/vue.d.ts >> ./dist/vue-i18n.d.ts",
     "build:watch": "tsc -p . --watch",
     "clean": "npm-run-all --parallel clean:*",
     "clean:cache": "yarn clean:cache:rollup && yarn clean:cache:jest",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "benchmark": "yarn build && node ./benchmark/index.js",
     "build": "node ./scripts/build.js",
     "build:sourcemap": "yarn build --sourcemap",
-    "build:type": "yarn build --types && tail -n +13 src/vue.d.ts >> ./dist/vue-i18n.d.ts",
+    "build:type": "yarn build --types && tail -n +14 src/vue.d.ts >> ./dist/vue-i18n.d.ts",
     "build:watch": "tsc -p . --watch",
     "clean": "npm-run-all --parallel clean:*",
     "clean:cache": "yarn clean:cache:rollup && yarn clean:cache:jest",

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -23,7 +23,7 @@ type VTDirectiveValue = {
 function getComposer<Messages, DateTimeFormats, NumberFormats>(
   i18n: I18n<Messages, DateTimeFormats, NumberFormats>,
   instance: ComponentInternalInstance
-): Composer<Messages, DateTimeFormats, NumberFormats> | null {
+): Composer<Messages, DateTimeFormats, NumberFormats> {
   const i18nInternal = (i18n as unknown) as I18nInternal
   if (i18n.mode === 'composable') {
     return (i18nInternal.__getInstance<
@@ -66,10 +66,6 @@ export function vTDirective<Messages, DateTimeFormats, NumberFormats>(
     }
 
     const composer = getComposer(i18n, instance.$)
-    if (!composer) {
-      throw createI18nError(I18nErrorCodes.NOT_FOUND_COMPOSER)
-    }
-
     if (__DEV__ && modifiers.preserve) {
       warn(getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_PRESERVE))
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -20,7 +20,6 @@ export const enum I18nErrorCodes {
   // diretive module errors
   REQUIRED_VALUE,
   INVALID_VALUE,
-  NOT_FOUND_COMPOSER,
   // for enhancement
   __EXTEND_POINT__
 }
@@ -43,6 +42,5 @@ export const errorMessages: { [code: number]: string } = {
   [I18nErrorCodes.UNEXPECTED_ERROR]: 'Unexpeced error',
   [I18nErrorCodes.NOT_AVAILABLE_IN_LEGACY_MODE]: 'Not available in legacy mode',
   [I18nErrorCodes.REQUIRED_VALUE]: `Required in value: {0}`,
-  [I18nErrorCodes.INVALID_VALUE]: `Invalid value`,
-  [I18nErrorCodes.NOT_FOUND_COMPOSER]: `Not found Composer`
+  [I18nErrorCodes.INVALID_VALUE]: `Invalid value`
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -56,11 +56,17 @@ export type I18nOptions = I18nAdditionalOptions &
  */
 export interface I18nAdditionalOptions {
   /**
-   * Whether vue-i18n legacy API use on your Vue App.
+   * Whether vue-i18n legacy API use on your Vue App
    *
    * @default false
    */
   legacy?: boolean
+  /**
+   * Whether Whether to inject global props & methods into for each component
+   *
+   * @default true
+   */
+  globalInjection?: boolean
 }
 
 /**
@@ -239,6 +245,7 @@ export function createI18n<
   Options['numberFormats']
 > {
   const __legacyMode = !!options.legacy
+  const __globalInjection = !options.globalInjection
   const __instances = new Map<
     ComponentInternalInstance,
     VueI18n<Messages> | Composer<Messages>
@@ -265,7 +272,7 @@ export function createI18n<
       app.__VUE_I18N_SYMBOL__ = symbol
       app.provide(app.__VUE_I18N_SYMBOL__, i18n)
 
-      if (!__legacyMode) {
+      if (!__legacyMode && __globalInjection) {
         injectGlobalFields<Messages, DateTimeFormats, NumberFormats>(
           app,
           i18n.global

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,8 @@ export {
   I18nMode,
   I18nScope,
   ComposerAdditionalOptions,
-  UseI18nOptions
+  UseI18nOptions,
+  ExportedComposer
 } from './i18n'
 export {
   Translation,

--- a/src/vue.d.ts
+++ b/src/vue.d.ts
@@ -1,5 +1,7 @@
 import { Path } from './path'
+import { NamedValue } from './message/runtime'
 import { Locale, LocaleMessageValue } from './core/context'
+import { TranslateOptions, DateTimeOptions, NumberOptions } from './core/index'
 import { CustomBlocks, VueMessageType } from './composer'
 import {
   VueI18n,
@@ -8,6 +10,7 @@ import {
   DateTimeFormatResult,
   NumberFormatResult
 } from './legacy'
+import { ExportedComposer } from './i18n'
 
 declare module '@vue/runtime-core' {
   export interface ComponentCustomOptions {
@@ -27,122 +30,119 @@ declare module '@vue/runtime-core' {
 
   export interface ComponentCustomProperties {
     /**
-     * VueI18n class compatible interface. See {@link VueI18n}
+     * Global composer instance, or a instance that are compatible with vue-i18n@v8.x VueI18n interface
      *
      * @remarks
-     * If you have specified an `i18n` option at component options,
-     * you will be able to get a VueI18n instance at the component,
-     * Otherwise, you will be able get root VueI18n instance.
+     * You can get the {@link I18n.global | global composer} created during the execution of {@link createI18n}.
+     * This instance is global property injected into for each components by `app.config.globalProperties`.
      *
-     * This property is supported for legacy API only
+     * If you have specified `legacy: true` in options at `createI18n`, that is in legacy mode, {@link VueI18n} instance is set to for each the components.
+     * Otherwise, you will be able get root VueI18n instance.
      */
-    $i18n?: VueI18n
+    $i18n: VueI18n | ExportedComposer
     /**
      * translation method
      *
-     * @param key - required, type {@link Path}
-     * @param locale - optional, type {@link Locale}
-     * @param values - optional, type `Array` or `Object`
-     * @returns translated string
-     *
      * @remarks
-     * Localize the locale message of `key`.
-     * Localize in preferentially component locale messages than global locale messages.
-     * If not specified component locale messages, localize with global locale messages.
-     * If you specified `locale`, localize the locale messages of `locale`.
-     * If you specified `key` of list / named formatting local messages, you must specify `values` too.
+     * In composable mode, In the case of composable mode, the method (property) is injected by `app.config.globalProperties`.
+     * the input / output is the same as for `Composer`, and it's **global**. About that details, see {@link Composer.t | `Composer#t` }.
      *
-     * This property is supported for legacy API only
+     * In legacy mode, the input / output is the same as for `VueI18n` of vue-i18n@v8.x. About that details, see {@link VueI18n.t | `VueI18n#t`}.
      */
-    $t?: (...args: unknown[]) => TranslateResult
+    $t(key: Path): TranslateResult
+    $t(key: Path, locale: Locale): TranslateResult
+    $t(key: Path, locale: Locale, list: unknown[]): TranslateResult
+    $t(key: Path, locale: Locale, named: object): TranslateResult
+    $t(key: Path, list: unknown[]): TranslateResult
+    $t(key: Path, named: Record<string, unknown>): TranslateResult
+    $t(key: Path): string
+    $t(key: Path, plural: number): string
+    $t(key: Path, plural: number, options: TranslateOptions): string
+    $t(key: Path, defaultMsg: string): string
+    $t(key: Path, defaultMsg: string, options: TranslateOptions): string
+    $t(key: Path, list: unknown[]): string
+    $t(key: Path, list: unknown[], plural: number): string
+    $t(key: Path, list: unknown[], defaultMsg: string): string
+    $t(key: Path, list: unknown[], options: TranslateOptions): string
+    $t(key: Path, named: NamedValue): string
+    $t(key: Path, named: NamedValue, plural: number): string
+    $t(key: Path, named: NamedValue, defaultMsg: string): string
+    $t(key: Path, named: NamedValue, options: TranslateOptions): string
     /**
      * pluralization method
      *
-     * @param key - required, type {@link Path}
-     * @param choice - optional, type `number`, default `1`
-     * @param locale - optional, type {@link Locale}
-     * @param values - optional, type `string` or `Array` or `Object`
-     * @returns pluralized string
-     *
      * @remarks
-     * Localize the locale message of `key` with pluralization.
-     * Localize in preferentially component locale messages than global locale messages.
-     * If not specified component locale messages, localize with global locale messages.
-     * If you specified `locale`, localize the locale messages of `locale`.
-     * If you will specify string value to `values`, localize the locale messages of value.
-     * If you will specify Array or Object value to `values`, you must specify with `values` of `$t`.
+     * The input / output is the same as for `VueI18n` of vue-i18n@v8.x. About that details, see {@link VueI18n.tc | `VueI18n#tc` }.
      *
-     * This property is supported for legacy API only
+     * This property is supported for legacy mode only
      */
-    $tc?: (...args: unknown[]) => TranslateResult
+    $tc(key: Path): TranslateResult
+    $tc(key: Path, locale: Locale): TranslateResult
+    $tc(key: Path, list: unknown[]): TranslateResult
+    $tc(key: Path, named: Record<string, unknown>): TranslateResult
+    $tc(key: Path, choice: number): TranslateResult
+    $tc(key: Path, choice: number, locale: Locale): TranslateResult
+    $tc(key: Path, choice: number, list: unknown[]): TranslateResult
+    $tc(
+      key: Path,
+      choice: number,
+      named: Record<string, unknown>
+    ): TranslateResult
     /**
      * translation exist method
      *
-     * @param key - required, type {@link Path}
-     * @param locale - optional, type {@link Locale}
-     * @returns key exsiting result
-     *
      * @remarks
-     * Check whether key exists.
-     * In Vue instance, If not specified component locale messages,
-     * check with global locale messages. If you specified `locale`, check the locale messages of `locale`
+     * The input / output is the same as for `VueI18n` of vue-i18n@v8.x. About that details, see {@link VueI18n.te | `VueI18n.#te` }.
      *
-     * This property is supported for legacy API only
+     * This property is supported for legacy mode only
      */
-    $te?: (key: Path, locale?: Locale) => boolean
+    $te(key: Path, locale?: Locale): boolean
     /**
      * datetime method
      *
-     * @param value - required, type `number` or `Date`
-     * @param key - optional, type {@link Path} or `Object`
-     * @param locale - optional, type {@link Locale}
-     * @returns formatted datetime result
-     *
      * @remarks
-     * Localize the datetime of `value` with datetime format of `key`.
-     * The datetime format of `key` need to register to `dateTimeFormats` option of {@link VueI18nOptions},
-     * and depend on `locale` option of {@link VueI18nOptions}.
-     * If you will specify locale argument, it will have priority over `locale` of {@link VueI18nOptions}.
+     * In composable mode, In the case of composable mode, the method (property) is injected by `app.config.globalProperties`.
+     * the input / output is the same as for `Composer`, and it's **global**. About that details, see {@link Composer.d | `Composer#d` }.
      *
-     * If the datetime format of `key` not exist in `dateTimeFormats` option,
-     * fallback to depend on `fallbackLocale` of {@link VueI18nOptions}.
-     *
-     * This property is supported for legacy API only
+     * In legacy mode, the input / output is the same as for `VueI18n` of vue-i18n@v8.x. About that details, see {@link VueI18n.d | `VueI18n#d` }.
      */
-    $d?: (...args: unknown[]) => DateTimeFormatResult
+    $d(value: number | Date): DateTimeFormatResult
+    $d(value: number | Date, key: string): DateTimeFormatResult
+    $d(value: number | Date, key: string, locale: Locale): DateTimeFormatResult
+    $d(
+      value: number | Date,
+      args: { [key: string]: string }
+    ): DateTimeFormatResult
+    $d(value: number | Date): string
+    $d(value: number | Date, key: string): string
+    $d(value: number | Date, key: string, locale: Locale): string
+    $d(value: number | Date, options: DateTimeOptions): string
     /**
      * number method
      *
-     * @param value - required, type `number`
-     * @param format - optional, type {@link Path} or `Object`
-     * @param locale - optional, type {@link Locale}
-     * @returns formatted number result
-     *
      * @remarks
-     * Localize the number of `value` with number format of `format`.
-     * The number format of `format` need to register to `numberFormats` option of {@link VueI18nOptions},
-     * and depend on `locale` option of {@link VueI18nOptions}.
-     * If you will specify `locale` argument, it will have priority over `locale` option of {@link VueI18nOptions}
+     * In composable mode, In the case of composable mode, the method (property) is injected by `app.config.globalProperties`.
+     * the input / output is the same as for `Composer`,  and it's **global**. About that details, see {@link Composer.n | `Composer.n` }.
      *
-     * If the number format of `format` not exist in `numberFormats` option,
-     * fallback to depend on `fallbackLocale` option of {@link VueI18nOptions}
-     *
-     * This property is supported for legacy API only
+     * In legacy mode, the input / output is the same as for `VueI18n` of vue-i18n@v8.x. About that details, see {@link VueI18n.n | `VueI18n.n` }.
      */
-    $n?: (...args: unknown[]) => NumberFormatResult
+    $n(value: number): NumberFormatResult
+    $n(value: number, key: string): NumberFormatResult
+    $n(value: number, key: string, locale: Locale): NumberFormatResult
+    $n(value: number, args: { [key: string]: string }): NumberFormatResult
+    $n(value: number): string
+    $n(value: number, key: string): string
+    $n(value: number, key: string, locale: Locale): string
+    $n(value: number, options: NumberOptions): string
     /**
      * translation messages method
      *
-     * @param key - required, target keypath
-     * @returns locale messages
-     *
      * @remarks
-     * Get the locale message of `key`.
-     * Get in preferentially component locale messages than global locale messages.
-     * If the target locale messages is not found locally, get it from the global, otherwise returns an empty object.
+     * In composable mode, In the case of composable mode, the method (property) is injected by `app.config.globalProperties`.
+     * the input / output is the same as for `Composer`, and it's **global**. About that details, see {@link Composer.tm | `Composer.tm` }.
      *
-     * This property is supported for legacy API only
+     * In legacy mode, the input / output is the same as for `VueI18n` of vue-i18n@v8.x. About that details, see {@link VueI18n.tm | `VueI18n#tm` }.
      */
-    $tm?: (key: Path) => LocaleMessageValue<VueMessageType> | {}
+    $tm(key: Path): LocaleMessageValue<VueMessageType> | {}
   }
 }

--- a/test/diretive.test.ts
+++ b/test/diretive.test.ts
@@ -197,39 +197,6 @@ test('using in template', async () => {
 })
 
 describe('errors', () => {
-  test(errorMessages[I18nErrorCodes.NOT_FOUND_COMPOSER], async () => {
-    const i18n = createI18n({
-      locale: 'en',
-      messages: {
-        en: {
-          hello: 'hello!'
-        }
-      }
-    })
-    const spy = jest.spyOn(i18n, 'global', 'get')
-    // @ts-ignore
-    spy.mockImplementation(() => null)
-
-    const App = defineComponent({
-      setup() {
-        const t = resolveDirective('t')
-        return () => {
-          return withDirectives(h('p'), [[t!, { locale: 'ja' }]])
-        }
-      }
-    })
-
-    let error: Error | null = null
-    try {
-      await mount(App, i18n)
-    } catch (e) {
-      error = e
-    }
-    expect(error!.message).toEqual(
-      errorMessages[I18nErrorCodes.NOT_FOUND_COMPOSER]
-    )
-  })
-
   test(errorMessages[I18nErrorCodes.REQUIRED_VALUE], async () => {
     const i18n = createI18n({
       locale: 'en',

--- a/test/mixin.test.ts
+++ b/test/mixin.test.ts
@@ -6,6 +6,7 @@ import { mount } from './helper'
 import { defineComponent, nextTick } from 'vue'
 import { createI18n } from '../src/i18n'
 import { errorMessages, I18nErrorCodes } from '../src/errors'
+import { VueI18n } from '../src/legacy'
 
 describe('beforeCreate', () => {
   test('i18n option', async () => {
@@ -173,7 +174,7 @@ test('$i18n', async () => {
   const App = defineComponent({ template: '<br/>' })
   const { vm } = await mount(App, i18n)
 
-  expect(vm.$i18n!.t('hello')).toEqual('hello!')
+  expect((vm.$i18n! as VueI18n).t('hello')).toEqual('hello!')
 })
 
 test('VueI18n componentInstanceCreatedListener option', async () => {


### PR DESCRIPTION
resolve #106

This PR is a PR to improve the DX of the API vue-i18n-next provides for the composition API.

This PR improves the following:
- no longer needs to call `useI18n` on each component when using global composer
- The following global props & methods are injected by `app.config.globalProperties`
  - `$i18n` prop: exported `locale`, `fallbackLocale` and `availableLocales` props
  - `$t` method
  - `$d` method
  - `$n` method
  - `$tm` method

