### PR TITLE
Fix `UNEXPECTED_ERROR` message typo

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -41,7 +41,7 @@ export const errorMessages: { [code: number]: string } = {
   [I18nErrorCodes.UNEXPECTED_RETURN_TYPE]: 'Unexpected return type in composer',
   [I18nErrorCodes.INVALID_ARGUMENT]: 'Invalid argument',
   [I18nErrorCodes.NOT_INSLALLED]: 'Need to install with app.use function',
-  [I18nErrorCodes.UNEXPECTED_ERROR]: 'Unexpeced error',
+  [I18nErrorCodes.UNEXPECTED_ERROR]: 'Unexpected error',
   [I18nErrorCodes.NOT_AVAILABLE_IN_LEGACY_MODE]: 'Not available in legacy mode',
   [I18nErrorCodes.REQUIRED_VALUE]: `Required in value: {0}`,
   [I18nErrorCodes.INVALID_VALUE]: `Invalid value`,


### PR DESCRIPTION
During my tests I found a typo in one of the error messages, as demonstrated below:

![Captura de tela 2020-10-03 175450](https://user-images.githubusercontent.com/12788435/95001568-8d188500-05a1-11eb-9cbe-2a3085c07b47.jpg)
