### PR TITLE
Allow d() to take an ISO string as parameter.

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -200,10 +200,10 @@ export interface Composer<
   t(key: Path, named: NamedValue, defaultMsg: string): string
   t(key: Path, named: NamedValue, options: TranslateOptions): string
   t(...args: unknown[]): string // for internal
-  d(value: number | Date): string
-  d(value: number | Date, key: string): string
-  d(value: number | Date, key: string, locale: Locale): string
-  d(value: number | Date, options: DateTimeOptions): string
+  d(value: number | Date | string): string
+  d(value: number | Date | string, key: string): string
+  d(value: number | Date | string, key: string, locale: Locale): string
+  d(value: number | Date | string, options: DateTimeOptions): string
   d(...args: unknown[]): string // for internal
   n(value: number): string
   n(value: number, key: string): string

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -211,10 +211,31 @@ export function parseDateTimeArgs(
   let options = {} as DateTimeOptions
   let orverrides = {} as Intl.DateTimeFormatOptions
 
-  if (!(isNumber(arg1) || isDate(arg1) || isString(arg1))) {
+  let value: number | Date
+  if (isString(arg1)) {
+    // Only allow ISO strings - other date formats are often supported,
+    // but may cause different results in different browsers.
+    if (!/\d{4}-\d{2}-\d{2}(T.*)?/.test(arg1)) {
+      throw createCoreError(CoreErrorCodes.INVALID_ISO_DATE_ARGUMENT)
+    }
+    value = new Date(arg1)
+
+    try {
+      // This will fail if the date is not valid
+      value.toISOString()
+    } catch (e) {
+      throw createCoreError(CoreErrorCodes.INVALID_ISO_DATE_ARGUMENT)
+    }
+  } else if (isDate(arg1)) {
+    if (isNaN(arg1.getTime())) {
+      throw createCoreError(CoreErrorCodes.INVALID_DATE_ARGUMENT)
+    }
+    value = arg1
+  } else if (isNumber(arg1)) {
+    value = arg1
+  } else {
     throw createCoreError(CoreErrorCodes.INVALID_ARGUMENT)
   }
-  const value = isString(arg1) ? new Date(arg1) : arg1
 
   if (isString(arg2)) {
     options.key = arg2

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -211,10 +211,10 @@ export function parseDateTimeArgs(
   let options = {} as DateTimeOptions
   let orverrides = {} as Intl.DateTimeFormatOptions
 
-  if (!(isNumber(arg1) || isDate(arg1))) {
+  if (!(isNumber(arg1) || isDate(arg1) || isString(arg1))) {
     throw createCoreError(CoreErrorCodes.INVALID_ARGUMENT)
   }
-  const value = arg1
+  const value = isString(arg1) ? new Date(arg1) : arg1
 
   if (isString(arg2)) {
     options.key = arg2

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -12,6 +12,8 @@ export interface CoreError extends CompileError {
 /** @internal */
 export const enum CoreErrorCodes {
   INVALID_ARGUMENT = CompileErrorCodes.__EXTEND_POINT__,
+  INVALID_DATE_ARGUMENT,
+  INVALID_ISO_DATE_ARGUMENT,
   __EXTEND_POINT__
 }
 
@@ -26,5 +28,10 @@ export function createCoreError(code: CoreErrorCodes): CoreError {
 
 /** @internal */
 export const errorMessages: { [code: number]: string } = {
-  [CoreErrorCodes.INVALID_ARGUMENT]: 'Invalid arguments'
+  [CoreErrorCodes.INVALID_ARGUMENT]: 'Invalid arguments',
+  [CoreErrorCodes.INVALID_DATE_ARGUMENT]:
+    'The date provided is an invalid Date object.' +
+    'Make sure your Date represents a valid date.',
+  [CoreErrorCodes.INVALID_ISO_DATE_ARGUMENT]:
+    'The argument provided is not a valid ISO date string'
 }

--- a/test/composer.test.ts
+++ b/test/composer.test.ts
@@ -624,6 +624,28 @@ describe('d', () => {
     const dt = new Date(Date.UTC(2012, 11, 20, 3, 0, 0))
     expect(d(dt, { key: 'long' })).toEqual('')
   })
+
+  test('iso', () => {
+    const { d } = createComposer({
+      locale: 'en-US',
+      datetimeFormats: {
+        'en-US': {
+          short: {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZone: 'America/New_York'
+          }
+        }
+      }
+    })
+    const dt = '2012-12-20T12:00:00Z'
+    expect(d(dt, { key: 'short', fallbackWarn: false })).toEqual(
+      '12/20/2012, 07:00 AM'
+    )
+  })
 })
 
 describe('n', () => {

--- a/test/core/datetime.test.ts
+++ b/test/core/datetime.test.ts
@@ -327,7 +327,19 @@ describe('error', () => {
     })
     expect(() => {
       datetime(ctx, '111')
+    }).toThrowError(errorMessages[CoreErrorCodes.INVALID_ISO_DATE_ARGUMENT])
+
+    expect(() => {
+      datetime(ctx, '2020-01-01TSomeDefinitelyInvalidString')
+    }).toThrowError(errorMessages[CoreErrorCodes.INVALID_ISO_DATE_ARGUMENT])
+
+    expect(() => {
+      datetime(ctx, { someObject: true })
     }).toThrowError(errorMessages[CoreErrorCodes.INVALID_ARGUMENT])
+
+    expect(() => {
+      datetime(ctx, new Date('invalid'))
+    }).toThrowError(errorMessages[CoreErrorCodes.INVALID_DATE_ARGUMENT])
   })
 })
 


### PR DESCRIPTION
Currently, only Date objects and number are allowed.

While using number may cause many problems (missing timezone information), a ISO string is a format returned by most APIs. So in my opinion, it makes more sense to allow an (ISO) string to be passed to this method.