### PR TITLE
fix: can't assign to property "processor" on false: not an object

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -767,8 +767,8 @@ export function createComposer<
     return wrapWithDeps<VNode, VNodeArrayChildren>(
       context => {
         let ret: unknown
+        const _context = context as RuntimeTranslationContext<Messages, VNode>
         try {
-          const _context = context as RuntimeTranslationContext<Messages, VNode>
           _context.processor = processor
           ret = translate<Messages, VNode>(_context, ...args)
         } finally {


### PR DESCRIPTION
`translateVNode` crashes in `finally` clause because `_context` variable doesn't exist in scope