### PR TITLE
Fix not to get loc when passing true to ParserOptions.location

### DIFF
--- a/packages/message-compiler/src/parser.ts
+++ b/packages/message-compiler/src/parser.ts
@@ -117,7 +117,7 @@ function fromEscapeSequence(
 }
 
 export function createParser(options: ParserOptions = {}): Parser {
-  const location = !options.location
+  const location = options.location !== false
 
   const { onError } = options
   function emitError(

--- a/packages/message-compiler/src/tokenizer.ts
+++ b/packages/message-compiler/src/tokenizer.ts
@@ -76,7 +76,7 @@ export function createTokenizer(
   source: string,
   options: TokenizeOptions = {}
 ): Tokenizer {
-  const location = !options.location
+  const location = options.location !== false
 
   const _scnr = createScanner(source)
 


### PR DESCRIPTION
This PR fixes an issue where passing `true` to `ParserOptions.location` would cause the parser not to generate the `loc`.