### PR TITLE
improvement(message-compiler): Change to generate AST with linked message error

### DIFF
--- a/packages/message-compiler/test/__snapshots__/parser.test.ts.snap
+++ b/packages/message-compiler/test/__snapshots__/parser.test.ts.snap
@@ -1,63 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`parse 1`] = `
-Object {
-  "body": Object {
-    "end": 11,
-    "items": Array [
-      Object {
-        "end": 11,
-        "loc": Object {
-          "end": Object {
-            "column": 12,
-            "line": 1,
-            "offset": 11,
-          },
-          "start": Object {
-            "column": 1,
-            "line": 1,
-            "offset": 0,
-          },
-        },
-        "start": 0,
-        "type": 3,
-        "value": "hello world",
-      },
-    ],
-    "loc": Object {
-      "end": Object {
-        "column": 12,
-        "line": 1,
-        "offset": 11,
-      },
-      "start": Object {
-        "column": 1,
-        "line": 1,
-        "offset": 0,
-      },
-    },
-    "start": 0,
-    "type": 2,
-  },
-  "end": 11,
-  "loc": Object {
-    "end": Object {
-      "column": 12,
-      "line": 1,
-      "offset": 11,
-    },
-    "source": "hello world",
-    "start": Object {
-      "column": 1,
-      "line": 1,
-      "offset": 0,
-    },
-  },
-  "start": 0,
-  "type": 0,
-}
-`;
-
 exports[`parse: linked 1`] = `
 Object {
   "body": Object {
@@ -131,6 +73,536 @@ Object {
   "start": 0,
   "type": 0,
 }
+`;
+
+exports[`parse: linked error 1`] = `
+Object {
+  "body": Object {
+    "end": 5,
+    "items": Array [
+      Object {
+        "end": 3,
+        "key": Object {
+          "end": 3,
+          "loc": Object {
+            "end": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+            "start": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+          },
+          "start": 3,
+          "type": 7,
+          "value": "",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 4,
+            "line": 1,
+            "offset": 3,
+          },
+          "start": Object {
+            "column": 1,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+        "modifier": Object {
+          "end": 1,
+          "loc": Object {
+            "end": Object {
+              "column": 2,
+              "line": 1,
+              "offset": 1,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 1,
+              "offset": 1,
+            },
+          },
+          "start": 1,
+          "type": 8,
+          "value": "",
+        },
+        "start": 0,
+        "type": 6,
+      },
+      Object {
+        "end": 5,
+        "loc": Object {
+          "end": Object {
+            "column": 6,
+            "line": 1,
+            "offset": 5,
+          },
+          "start": Object {
+            "column": 4,
+            "line": 1,
+            "offset": 3,
+          },
+        },
+        "start": 3,
+        "type": 3,
+        "value": " a",
+      },
+    ],
+    "loc": Object {
+      "end": Object {
+        "column": 6,
+        "line": 1,
+        "offset": 5,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+        "offset": 0,
+      },
+    },
+    "start": 0,
+    "type": 2,
+  },
+  "end": 5,
+  "loc": Object {
+    "end": Object {
+      "column": 6,
+      "line": 1,
+      "offset": 5,
+    },
+    "source": "@.: a",
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "start": 0,
+  "type": 0,
+}
+`;
+
+exports[`parse: linked error errors 1`] = `
+Array [
+  Object {
+    "code": 11,
+    "domain": "parser",
+    "location": Object {
+      "end": Object {
+        "column": 4,
+        "line": 1,
+        "offset": 3,
+      },
+      "start": Object {
+        "column": 2,
+        "line": 1,
+        "offset": 1,
+      },
+    },
+    "message": "Unexpected lexical analysis in token: '10'",
+  },
+  Object {
+    "code": 9,
+    "domain": "tokenizer",
+    "location": Object {
+      "end": Object {
+        "column": 4,
+        "line": 1,
+        "offset": 3,
+      },
+      "start": Object {
+        "column": 4,
+        "line": 1,
+        "offset": 3,
+      },
+    },
+    "message": "Invalid linked format",
+  },
+  Object {
+    "code": 11,
+    "domain": "parser",
+    "location": Object {
+      "end": Object {
+        "column": 6,
+        "line": 1,
+        "offset": 5,
+      },
+      "start": Object {
+        "column": 3,
+        "line": 1,
+        "offset": 2,
+      },
+    },
+    "message": "Unexpected lexical analysis in token: '0'",
+  },
+]
+`;
+
+exports[`parse: linked key paren error 1`] = `
+Object {
+  "body": Object {
+    "end": 7,
+    "items": Array [
+      Object {
+        "end": 2,
+        "key": Object {
+          "end": 2,
+          "loc": Object {
+            "end": Object {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+            "start": Object {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+          },
+          "start": 2,
+          "type": 7,
+          "value": "",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 3,
+            "line": 1,
+            "offset": 2,
+          },
+          "start": Object {
+            "column": 1,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+        "start": 0,
+        "type": 6,
+      },
+      Object {
+        "end": 7,
+        "loc": Object {
+          "end": Object {
+            "column": 8,
+            "line": 1,
+            "offset": 7,
+          },
+          "start": Object {
+            "column": 3,
+            "line": 1,
+            "offset": 2,
+          },
+        },
+        "start": 2,
+        "type": 3,
+        "value": "(foo)",
+      },
+    ],
+    "loc": Object {
+      "end": Object {
+        "column": 8,
+        "line": 1,
+        "offset": 7,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+        "offset": 0,
+      },
+    },
+    "start": 0,
+    "type": 2,
+  },
+  "end": 7,
+  "loc": Object {
+    "end": Object {
+      "column": 8,
+      "line": 1,
+      "offset": 7,
+    },
+    "source": "@:(foo)",
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "start": 0,
+  "type": 0,
+}
+`;
+
+exports[`parse: linked key paren error errors 1`] = `
+Array [
+  Object {
+    "code": 11,
+    "domain": "parser",
+    "location": Object {
+      "end": Object {
+        "column": 8,
+        "line": 1,
+        "offset": 7,
+      },
+      "start": Object {
+        "column": 2,
+        "line": 1,
+        "offset": 1,
+      },
+    },
+    "message": "Unexpected lexical analysis in token: '0'",
+  },
+]
+`;
+
+exports[`parse: linked key paren error with modifier 1`] = `
+Object {
+  "body": Object {
+    "end": 13,
+    "items": Array [
+      Object {
+        "end": 8,
+        "key": Object {
+          "end": 8,
+          "loc": Object {
+            "end": Object {
+              "column": 9,
+              "line": 1,
+              "offset": 8,
+            },
+            "start": Object {
+              "column": 9,
+              "line": 1,
+              "offset": 8,
+            },
+          },
+          "start": 8,
+          "type": 7,
+          "value": "",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 9,
+            "line": 1,
+            "offset": 8,
+          },
+          "start": Object {
+            "column": 1,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+        "modifier": Object {
+          "end": 7,
+          "loc": Object {
+            "end": Object {
+              "column": 8,
+              "line": 1,
+              "offset": 7,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 1,
+              "offset": 1,
+            },
+          },
+          "start": 1,
+          "type": 8,
+          "value": "lower",
+        },
+        "start": 0,
+        "type": 6,
+      },
+      Object {
+        "end": 13,
+        "loc": Object {
+          "end": Object {
+            "column": 14,
+            "line": 1,
+            "offset": 13,
+          },
+          "start": Object {
+            "column": 9,
+            "line": 1,
+            "offset": 8,
+          },
+        },
+        "start": 8,
+        "type": 3,
+        "value": "(foo)",
+      },
+    ],
+    "loc": Object {
+      "end": Object {
+        "column": 14,
+        "line": 1,
+        "offset": 13,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+        "offset": 0,
+      },
+    },
+    "start": 0,
+    "type": 2,
+  },
+  "end": 13,
+  "loc": Object {
+    "end": Object {
+      "column": 14,
+      "line": 1,
+      "offset": 13,
+    },
+    "source": "@.lower:(foo)",
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "start": 0,
+  "type": 0,
+}
+`;
+
+exports[`parse: linked key paren error with modifier errors 1`] = `
+Array [
+  Object {
+    "code": 11,
+    "domain": "parser",
+    "location": Object {
+      "end": Object {
+        "column": 14,
+        "line": 1,
+        "offset": 13,
+      },
+      "start": Object {
+        "column": 8,
+        "line": 1,
+        "offset": 7,
+      },
+    },
+    "message": "Unexpected lexical analysis in token: '0'",
+  },
+]
+`;
+
+exports[`parse: linked modifier error 1`] = `
+Object {
+  "body": Object {
+    "end": 6,
+    "items": Array [
+      Object {
+        "end": 6,
+        "key": Object {
+          "end": 6,
+          "loc": Object {
+            "end": Object {
+              "column": 7,
+              "line": 1,
+              "offset": 6,
+            },
+            "start": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+          },
+          "start": 3,
+          "type": 7,
+          "value": "foo",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 7,
+            "line": 1,
+            "offset": 6,
+          },
+          "start": Object {
+            "column": 1,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+        "modifier": Object {
+          "end": 1,
+          "loc": Object {
+            "end": Object {
+              "column": 2,
+              "line": 1,
+              "offset": 1,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 1,
+              "offset": 1,
+            },
+          },
+          "start": 1,
+          "type": 8,
+          "value": "",
+        },
+        "start": 0,
+        "type": 6,
+      },
+    ],
+    "loc": Object {
+      "end": Object {
+        "column": 7,
+        "line": 1,
+        "offset": 6,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+        "offset": 0,
+      },
+    },
+    "start": 0,
+    "type": 2,
+  },
+  "end": 6,
+  "loc": Object {
+    "end": Object {
+      "column": 7,
+      "line": 1,
+      "offset": 6,
+    },
+    "source": "@.:foo",
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "start": 0,
+  "type": 0,
+}
+`;
+
+exports[`parse: linked modifier error errors 1`] = `
+Array [
+  Object {
+    "code": 11,
+    "domain": "parser",
+    "location": Object {
+      "end": Object {
+        "column": 4,
+        "line": 1,
+        "offset": 3,
+      },
+      "start": Object {
+        "column": 2,
+        "line": 1,
+        "offset": 1,
+      },
+    },
+    "message": "Unexpected lexical analysis in token: '10'",
+  },
+]
 `;
 
 exports[`parse: linked modifier list 1`] = `
@@ -403,6 +875,64 @@ Object {
       "offset": 19,
     },
     "source": "hello {'kazupon'} !",
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "start": 0,
+  "type": 0,
+}
+`;
+
+exports[`parse: message 1`] = `
+Object {
+  "body": Object {
+    "end": 11,
+    "items": Array [
+      Object {
+        "end": 11,
+        "loc": Object {
+          "end": Object {
+            "column": 12,
+            "line": 1,
+            "offset": 11,
+          },
+          "start": Object {
+            "column": 1,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+        "start": 0,
+        "type": 3,
+        "value": "hello world",
+      },
+    ],
+    "loc": Object {
+      "end": Object {
+        "column": 12,
+        "line": 1,
+        "offset": 11,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+        "offset": 0,
+      },
+    },
+    "start": 0,
+    "type": 2,
+  },
+  "end": 11,
+  "loc": Object {
+    "end": Object {
+      "column": 12,
+      "line": 1,
+      "offset": 11,
+    },
+    "source": "hello world",
     "start": Object {
       "column": 1,
       "line": 1,


### PR DESCRIPTION
This PR improves AST and error emission when the linked message is misformatted.

e.g.

- `@:(foo)`:
  - before:  
    ```js
    body: [
      {
        type: /* LinkedNode */
      }
    ],
    errors: []
    ```
  - after:  
    ```js
    body: [
      {
        type: /* LinkedNode */,
        key: {
          type: /* LinkedKeyNode */,
          value: '' /*empty*/
        }
      },
      {
        type: /* TextNode */,
        value: '(foo)'
      }
    ],
    errors: [
      { message: "Unexpected lexical analysis in token: 'xx'"}
    ]
    ```

- `@.:foo`:
  - before:  
    ```js
    body: [
      {
        type: /* LinkedNode */,
        modifier: {
          value: ':'
        }
      }
    ],
    errors: [
      { message: "Unexpected lexical analysis in token: 'xx'"}
    ]
    ```
  - after:  
    ```js
    body: [
      {
        type: /* LinkedNode */,
        modifier: {
          value: ''  /*empty*/
        },
        key: {
          type: /* LinkedKeyNode */,
          value: 'foo'
        }
      },
    ],
    errors: [
      { message: "Unexpected lexical analysis in token: 'xx'"}
    ]
    ```


- `@.: foo`:
  - before:  
    ```js
    body: [
      {
        type: /* LinkedNode */,
        modifier: {
          value: ':'
        }
      }
    ],
    errors: [
      { message: "Invalid linked format"},
      { message: "Unexpected lexical analysis in token: 'xx'"},
    ]
    ```
  - after:  
    ```js
    body: [
      {
        type: /* LinkedNode */,
        modifier: {
          value: ''  /*empty*/
        },
        key: {
          type: /* LinkedKeyNode */,
          value: '' /*empty*/
        }
      },
      {
        type: /* TextNode */,
        value: ' foo'
      },
    ],
    errors: [
      { message: "Unexpected lexical analysis in token: 'xx'"},
      { message: "Invalid linked format"},
      { message: "Unexpected lexical analysis in token: 'xx'"},
    ]
    ```

A node with an empty value might have to replace it with null, but I've placed an empty node so that it doesn't change the node types.
