### PR TITLE
docs: update installing for esm bundler

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -110,7 +110,7 @@ Global builds are not [UMD](https://github.com/umdjs/umd) builds. They are built
     - This means you **can** install/import these deps individually without ending up with different instances of these dependencies, but you must make sure they all resolve to the same version
   - In-browser locale messages compilation:
     - **`vue-i18n.runtime.esm-bundler.js`** is runtime only, and requires all locale messages to be pre-compiled. This is the default entry for bundlers (via `module` field in `package.json`) because when using a bundler templates are typically pre-compiled (e.g. in `*.json` files)
-    - **`vue-i18n.esm-bundler.js` (default)**: includes the runtime compiler. Use this if you are using a bundler but still want locale messages compilation (e.g. templates via inline JavaScript strings)
+    - **`vue-i18n.esm-bundler.js` (default)**: includes the runtime compiler. Use this if you are using a bundler but still want locale messages compilation (e.g. templates via inline JavaScript strings).  To use this build, change your import statement to: `import { createI18n } from "vue-i18n/dist/vue-i18n.esm-bundler.js";`
 
 :::tip NOTE
 If you use `vue-i18n.runtime.esm-bundler.js`, you will need to precompile all locale messages, and you can do that with `.json` (`.json5`) or `.yaml`, i18n custom blocks to manage i18n resources. Therefore, you can be going to pre-compile all locale messages with bundler and the following loader / plugin.


### PR DESCRIPTION
Adding an example showing how to `import` from a different build.  This is the one asked about most frequently on Stack Overflow, so I think it's nice to have in this section, but maybe it should go somewhere else.

