### PR TITLE
fix #262: test fail in some cases

### DIFF
--- a/packages/vue-i18n/test/composer.test.ts
+++ b/packages/vue-i18n/test/composer.test.ts
@@ -712,10 +712,10 @@ describe('n', () => {
 
   test('minimumFractionDigits, maximumFractionDigits', () => {
     const { n } = createComposer({
-      locale: 'US',
+      locale: 'en-US',
       fallbackLocale: ['ja-JP'],
       numberFormats: {
-        US: {
+        'en-US': {
           currency: {
             style: 'currency',
             currency: 'USD',


### PR DESCRIPTION
The test 'minimumFractionDigits, maximumFractionDigits' failed with log
```
● n › minimumFractionDigits, maximumFractionDigits

    expect(received).toEqual(expected) // deep equality

    Expected: "$0.99"
    Received: "US$ 0.99"

      746 |       }
      747 |     })
    > 748 |     expect(n(0.99, { key: 'currency', fallbackWarn: false })).toEqual('$0.99')
          |                                                               ^
      749 |     expect(n(1.1111, { key: 'decimal', fallbackWarn: false })).toEqual('1.11')
      750 |   })
      751 | 

      at Object.<anonymous> (packages/vue-i18n/test/composer.test.ts:748:63)
```

This problem is caused by the `Intl.NumberFormat` : we are testing with locale `US`, which is not supported locale
```javascript
const locales1 = ['US', 'en-US'];
const options1 = { localeMatcher: 'lookup' };

console.log(Intl.NumberFormat.supportedLocalesOf(locales1, options1));
```

Therefore, the output of `Intl.NumberFormat` wil be decided by the runtime's default locale. This could be tested with
```javascript
console.log(new Intl.NumberFormat('US', { style: 'currency', currency: 'USD' }).format(123456.789));
```

I'm using Windows and Ubuntu20.04 with language of Chinese, and I'm getting the `US$123,456.79` instead of `$123,456.79`.

Related to issue #262