### PR TITLE
Add support for flat json separated with dot('.')

### DIFF
--- a/packages/message-resolver/test/index.test.ts
+++ b/packages/message-resolver/test/index.test.ts
@@ -1,4 +1,4 @@
-import { parse, resolveValue } from '../src/index'
+import { parse, resolveValue, handleFlatJson } from '../src/index'
 
 test('parse', () => {
   expect(parse('a')).toEqual(['a'])
@@ -120,4 +120,30 @@ test('resolveValue', () => {
   expect(resolveValue({}, 'a.b.c[]')).toEqual(null)
   // blanket middle
   expect(resolveValue({}, 'a.b.c[]d')).toEqual(null)
+})
+
+test('handleFlatJson', () => {
+  const obj = {
+    a: { a1: 'a1.value' },
+    'a.a2': 'a.a2.value',
+    'b.x': {
+      'b1.x': 'b1.x.value',
+      'b2.x': ['b2.x.value0', 'b2.x.value1'],
+      'b3.x': { 'b3.x': 'b3.x.value' }
+    }
+  }
+
+  handleFlatJson(obj)
+
+  expect(obj['a']['a1'] === 'a1.value').toEqual(true)
+  // @ts-ignore
+  expect(obj['a']['a2'] === 'a.a2.value').toEqual(true)
+  // @ts-ignore
+  expect(obj['b']['x']['b1']['x'] === 'b1.x.value').toEqual(true)
+  // @ts-ignore
+  expect(obj['b']['x']['b2']['x'][0] === 'b2.x.value0').toEqual(true)
+  // @ts-ignore
+  expect(obj['b']['x']['b2']['x'][1] === 'b2.x.value1').toEqual(true)
+  // @ts-ignore
+  expect(obj['b']['x']['b3']['x']['b3']['x'] === 'b3.x.value').toEqual(true)
 })

--- a/packages/vue-i18n/src/composer.ts
+++ b/packages/vue-i18n/src/composer.ts
@@ -32,7 +32,8 @@ import {
   parseNumberArgs,
   clearNumberFormat,
   NOT_REOSLVED,
-  DevToolsTimelineEvents
+  DevToolsTimelineEvents,
+  handleFlatJson
 } from '@intlify/core-base'
 import { I18nWarnCodes, getWarnMessage } from './warnings'
 import { I18nErrorCodes, createI18nError } from './errors'
@@ -957,6 +958,13 @@ export function getLocaleMessages<Message = VueMessageType>(
         deepCopy(resource, ret)
       }
     })
+  }
+
+  // handle messages for flat json
+  for (const key in ret) {
+    if (ret.hasOwnProperty(key)) {
+      handleFlatJson(ret[key])
+    }
   }
 
   return ret

--- a/packages/vue-i18n/test/i18n.test.ts
+++ b/packages/vue-i18n/test/i18n.test.ts
@@ -27,6 +27,29 @@ describe('createI18n', () => {
 
     expect(i18n.mode).toEqual('composition')
   })
+
+  test('flat json message in legacy mode', () => {
+    const i18n = createI18n({
+      messages: {
+        en: { 'mainMenu.buttonStart': 'Start!' }
+      }
+    })
+    const messages = i18n.global.messages
+    // @ts-ignore
+    expect(messages['en']['mainMenu']['buttonStart'] === 'Start!').toEqual(true)
+  })
+
+  test('flat json message in composition mode', () => {
+    const i18n = createI18n({
+      legacy: false,
+      messages: {
+        en: { 'mainMenu.buttonStart': 'Start!' }
+      }
+    })
+    const messages = i18n.global.messages.value
+    // @ts-ignore
+    expect(messages['en']['mainMenu']['buttonStart'] === 'Start!').toEqual(true)
+  })
 })
 
 describe('useI18n', () => {


### PR DESCRIPTION
This is an implemention for #271.

With `handleFlatJson`, we can recrusively search the object for keys containing dot('.'), and transform the flat structure to normal structure so we can handle them as before.

The corresponding tests are also included.