### PR TITLE
fix `hasOwnProperty is not a function`

### DIFF
--- a/packages/message-resolver/src/index.ts
+++ b/packages/message-resolver/src/index.ts
@@ -1,4 +1,4 @@
-import { isObject } from '@intlify/shared'
+import { isObject, hasOwn } from '@intlify/shared'
 
 /** @VueI18nGeneral */
 export type Path = string
@@ -333,7 +333,7 @@ export function handleFlatJson(obj: unknown): unknown {
 
   for (const key in obj as object) {
     // check key
-    if (!obj.hasOwnProperty(key)) {
+    if (!hasOwn(obj, key)) {
       continue
     }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -113,6 +113,11 @@ export function escapeHtml(rawText: string): string {
     .replace(/'/g, '&apos;')
 }
 
+const hasOwnProperty = Object.prototype.hasOwnProperty
+export function hasOwn(obj: object | Array<any>, key: string): boolean {
+  return hasOwnProperty.call(obj, key)
+}
+
 /* eslint-enable */
 
 /**

--- a/packages/vue-i18n/src/composer.ts
+++ b/packages/vue-i18n/src/composer.ts
@@ -16,7 +16,8 @@ import {
   isBoolean,
   isPlainObject,
   makeSymbol,
-  isObject
+  isObject,
+  hasOwn
 } from '@intlify/shared'
 import {
   resolveValue,
@@ -962,18 +963,12 @@ export function getLocaleMessages<Message = VueMessageType>(
 
   // handle messages for flat json
   for (const key in ret) {
-    if (ret.hasOwnProperty(key)) {
+    if (hasOwn(ret, key)) {
       handleFlatJson(ret[key])
     }
   }
 
   return ret
-}
-
-const hasOwnProperty = Object.prototype.hasOwnProperty
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function hasOwn(obj: object | Array<any>, key: string): boolean {
-  return hasOwnProperty.call(obj, key)
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fix #305

We should use function ` Object.prototype.hasOwnProperty.call` instead of function `hasOwnProperty` to check property.
Sorry for not consider enough before.

I notice there is a function [hasOwn](https://github.com/intlify/vue-i18n-next/blob/dcd005c238151b0924163b679992185755785af7/packages/vue-i18n/src/composer.ts#L973) in `packages/vue-i18n/src/composer.ts`.
This PR would like to move function `hasOwn` to `/packages/shared/src/index.ts` and replace all `hasOwnProperty` call with `hasOwn` call.