### PR TITLE
Fix spelling line 195 for sfc doc : lessages to messages

### DIFF
--- a/docs/guide/advanced/sfc.md
+++ b/docs/guide/advanced/sfc.md
@@ -192,7 +192,7 @@ export default [
 ```
 
 
-## Define locale lessages importing
+## Define locale messages importing
 
 You can use `src` attribute:
 


### PR DESCRIPTION
I think it was "messages" unless my English is failing me. My bad if it is the case. Thanks for your work btw !

