### PR TITLE
fix won't fallback when `fallbackLocale` is empty string, and add a test

### DIFF
--- a/packages/core-base/src/context.ts
+++ b/packages/core-base/src/context.ts
@@ -353,13 +353,9 @@ export function handleMissing<Message = string>(
 export function getLocaleChain<Message = string>(
   ctx: CoreCommonContext<Message>,
   fallback: FallbackLocale,
-  start: Locale = ''
+  start: Locale
 ): Locale[] {
   const context = (ctx as unknown) as CoreInternalContext
-
-  if (start === '') {
-    return []
-  }
 
   if (!context.__localeChainCache) {
     context.__localeChainCache = new Map()

--- a/packages/core-base/test/context.test.ts
+++ b/packages/core-base/test/context.test.ts
@@ -204,6 +204,10 @@ describe('getLocaleChain', () => {
   })
 
   describe(`simple: 'en'`, () => {
+    test('empty string', () => {
+      expect(getLocaleChain(ctx, 'en', '')).toEqual(['en'])
+    })
+
     test('en', () => {
       expect(getLocaleChain(ctx, 'en', 'en')).toEqual(['en'])
     })


### PR DESCRIPTION
Fix #328

Fix won't fallback when `fallbackLocale` is empty string, and add a test.