### PR TITLE
fix for function `mergeLocaleMessage`, and modify some tests

### DIFF
--- a/packages/vue-i18n/src/composer.ts
+++ b/packages/vue-i18n/src/composer.ts
@@ -1423,10 +1423,8 @@ export function createComposer<
     locale: Locale,
     message: LocaleMessageDictionary<Message>
   ): void {
-    _messages.value[locale] = Object.assign(
-      _messages.value[locale] || {},
-      message
-    )
+    _messages.value[locale] = _messages.value[locale] || {}
+    deepCopy(message, _messages.value[locale])
     _context.messages = _messages.value as typeof _context.messages
   }
 

--- a/packages/vue-i18n/test/composer.test.ts
+++ b/packages/vue-i18n/test/composer.test.ts
@@ -875,13 +875,15 @@ describe('getLocaleMessage / setLocaleMessage / mergeLocaleMessage', () => {
     })
     expect(getLocaleMessage('en')).toEqual({ hello: 'Hello!' })
 
-    setLocaleMessage('en', { hi: 'Hi!' })
-    expect(getLocaleMessage('en')).toEqual({ hi: 'Hi!' })
+    setLocaleMessage('en', { hi: { hi: 'Hi!' } })
+    expect(getLocaleMessage('en')).toEqual({ hi: { hi: 'Hi!' } })
 
-    mergeLocaleMessage('en', { hello: 'Hello!' })
+    mergeLocaleMessage('en', { hi: { hello: 'Hello!' } })
     expect(getLocaleMessage('en')).toEqual({
-      hello: 'Hello!',
-      hi: 'Hi!'
+      hi: {
+        hi: 'Hi!',
+        hello: 'Hello!'
+      }
     })
   })
 })

--- a/packages/vue-i18n/test/i18n.test.ts
+++ b/packages/vue-i18n/test/i18n.test.ts
@@ -554,7 +554,7 @@ test('merge useI18n resources to global scope', async () => {
     locale: 'ja',
     messages: {
       en: {
-        hello: 'hello!'
+        hi: { hello: 'hello!' }
       }
     }
   })
@@ -564,6 +564,9 @@ test('merge useI18n resources to global scope', async () => {
       useI18n({
         useScope: 'global',
         messages: {
+          en: {
+            hi: { hi: 'hi!' }
+          },
           ja: {
             hello: 'こんにちは！'
           }
@@ -595,6 +598,12 @@ test('merge useI18n resources to global scope', async () => {
   })
   await mount(App, i18n)
 
+  expect(i18n.global.getLocaleMessage('en')).toEqual({
+    hi: {
+      hi: 'hi!',
+      hello: 'hello!'
+    }
+  })
   expect(i18n.global.getLocaleMessage('ja')).toEqual({ hello: 'こんにちは！' })
   expect(i18n.global.getDateTimeFormat('en-US')).toEqual({
     short: {
@@ -620,7 +629,7 @@ test('merge i18n custom blocks to global scope', async () => {
     locale: 'ja',
     messages: {
       en: {
-        hello: 'hello!'
+        hi: { hello: 'hello!' }
       }
     }
   })
@@ -635,7 +644,10 @@ test('merge i18n custom blocks to global scope', async () => {
       options.__i18nGlobal = [
         {
           locale: 'en',
-          resource: { foo: 'foo!' }
+          resource: {
+            hi: { hi: 'hi!' },
+            foo: 'foo!'
+          }
         },
         {
           locale: 'ja',
@@ -657,7 +669,10 @@ test('merge i18n custom blocks to global scope', async () => {
   await mount(App, i18n)
 
   expect(i18n.global.getLocaleMessage('en')).toEqual({
-    hello: 'hello!',
+    hi: {
+      hi: 'hi!',
+      hello: 'hello!'
+    },
     foo: 'foo!'
   })
   expect(i18n.global.getLocaleMessage('ja')).toEqual({

--- a/packages/vue-i18n/test/legacy.test.ts
+++ b/packages/vue-i18n/test/legacy.test.ts
@@ -298,13 +298,15 @@ test('getLocaleMessage / setLocaleMessage / mergeLocaleMessage', () => {
   })
   expect(i18n.getLocaleMessage('en')).toEqual({ hello: 'Hello!' })
 
-  i18n.setLocaleMessage('en', { hi: 'Hi!' })
-  expect(i18n.getLocaleMessage('en')).toEqual({ hi: 'Hi!' })
+  i18n.setLocaleMessage('en', { hi: { hi: 'hi!' } })
+  expect(i18n.getLocaleMessage('en')).toEqual({ hi: { hi: 'hi!' } })
 
-  i18n.mergeLocaleMessage('en', { hello: 'Hello!' })
+  i18n.mergeLocaleMessage('en', { hi: { hello: 'hello!' } })
   expect(i18n.getLocaleMessage('en')).toEqual({
-    hello: 'Hello!',
-    hi: 'Hi!'
+    hi: {
+      hi: 'hi!',
+      hello: 'hello!'
+    }
   })
 })
 


### PR DESCRIPTION
The existing `mergeLocaleMessage` use `Object.assign` to merge. 
There is some problems when merge two complex object.
These problems could be tested with my testcase which I have modified in this PR.
This PR would like to fix these problems.