### PR TITLE
Ignore debug.log file that create by vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 .DS_Store
 .idea
 .vscode
+debug.log
 
 # jest dump files
 report*.json


### PR DESCRIPTION
Sometimes `vscode` will create a `debug.log` file, maybe we can ignore it. 