### PR TITLE
Fix eslint warning in example project

### DIFF
--- a/examples/lazy-loading/vite/src/App.vue
+++ b/examples/lazy-loading/vite/src/App.vue
@@ -1,28 +1,30 @@
 <template>
-  <nav>
-    <div class="navigation">
-      <router-link :to="{ name: 'home', params: { locale } }">
-        {{ t('navigations.home') }}
-      </router-link>
-      |
-      <router-link :to="{ name: 'about', params: { locale } }">
-        {{ t('navigations.about') }}
-      </router-link>
-    </div>
-    <form class="language">
-      <label>{{ t('labels.language') }}</label>
-      <select v-model="currentLocale">
-        <option
-          v-for="optionLocale in supportLocales"
-          :key="optionLocale"
-          :value="optionLocale"
-        >
-          {{ optionLocale }}
-        </option>
-      </select>
-    </form>
-  </nav>
-  <router-view />
+  <div>
+    <nav>
+      <div class="navigation">
+        <router-link :to="{ name: 'home', params: { locale } }">
+          {{ t('navigations.home') }}
+        </router-link>
+        |
+        <router-link :to="{ name: 'about', params: { locale } }">
+          {{ t('navigations.about') }}
+        </router-link>
+      </div>
+      <form class="language">
+        <label>{{ t('labels.language') }}</label>
+        <select v-model="currentLocale">
+          <option
+            v-for="optionLocale in supportLocales"
+            :key="optionLocale"
+            :value="optionLocale"
+          >
+            {{ optionLocale }}
+          </option>
+        </select>
+      </form>
+    </nav>
+    <router-view />
+  </div>
 </template>
 
 <script>

--- a/examples/lazy-loading/webpack/src/App.vue
+++ b/examples/lazy-loading/webpack/src/App.vue
@@ -1,28 +1,30 @@
 <template>
-  <nav>
-    <div class="navigation">
-      <router-link :to="{ name: 'home', params: { locale } }">
-        {{ t('navigations.home') }}
-      </router-link>
-      |
-      <router-link :to="{ name: 'about', params: { locale } }">
-        {{ t('navigations.about') }}
-      </router-link>
-    </div>
-    <form class="language">
-      <label>{{ t('labels.language') }}</label>
-      <select v-model="currentLocale">
-        <option
-          v-for="optionLocale in supportLocales"
-          :key="optionLocale"
-          :value="optionLocale"
-        >
-          {{ optionLocale }}
-        </option>
-      </select>
-    </form>
-  </nav>
-  <router-view />
+  <div>
+    <nav>
+      <div class="navigation">
+        <router-link :to="{ name: 'home', params: { locale } }">
+          {{ t('navigations.home') }}
+        </router-link>
+        |
+        <router-link :to="{ name: 'about', params: { locale } }">
+          {{ t('navigations.about') }}
+        </router-link>
+      </div>
+      <form class="language">
+        <label>{{ t('labels.language') }}</label>
+        <select v-model="currentLocale">
+          <option
+            v-for="optionLocale in supportLocales"
+            :key="optionLocale"
+            :value="optionLocale"
+          >
+            {{ optionLocale }}
+          </option>
+        </select>
+      </form>
+    </nav>
+    <router-view />
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
There is a warning in example project `examples/lazy-loading/webpack` and `examples/lazy-loading/vite` :
```
[vue/valid-template-root]
The template root requires exactly one element.eslint-plugin-vue
```

This PR is a fix for it.