### PR TITLE
Add support for flat json separated with dot('.')

### DIFF
--- a/packages/message-resolver/test/index.test.ts
+++ b/packages/message-resolver/test/index.test.ts
@@ -1,4 +1,4 @@
-import { parse, resolveValue } from '../src/index'
+import { parse, resolveValue, handleFlatJson } from '../src/index'
 
 test('parse', () => {
   expect(parse('a')).toEqual(['a'])
@@ -120,4 +120,30 @@ test('resolveValue', () => {
   expect(resolveValue({}, 'a.b.c[]')).toEqual(null)
   // blanket middle
   expect(resolveValue({}, 'a.b.c[]d')).toEqual(null)
+})
+
+test('handleFlatJson', () => {
+  const obj = {
+    a: { a1: 'a1.value' },
+    'a.a2': 'a.a2.value',
+    'b.x': {
+      'b1.x': 'b1.x.value',
+      'b2.x': ['b2.x.value0', 'b2.x.value1'],
+      'b3.x': { 'b3.x': 'b3.x.value' }
+    }
+  }
+  const expectObj = {
+    a: {
+      a1: 'a1.value',
+      a2: 'a.a2.value'
+    },
+    b: {
+      x: {
+        b1: { x: 'b1.x.value' },
+        b2: { x: ['b2.x.value0', 'b2.x.value1'] },
+        b3: { x: { b3: { x: 'b3.x.value' } } }
+      }
+    }
+  }
+  expect(handleFlatJson(obj)).toEqual(expectObj)
 })

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -115,6 +115,11 @@ export function escapeHtml(rawText: string): string {
     .replace(/'/g, '&apos;')
 }
 
+const hasOwnProperty = Object.prototype.hasOwnProperty
+export function hasOwn(obj: object | Array<any>, key: string): boolean {
+  return hasOwnProperty.call(obj, key)
+}
+
 /* eslint-enable */
 
 /**

--- a/packages/vue-i18n/src/composer.ts
+++ b/packages/vue-i18n/src/composer.ts
@@ -16,7 +16,8 @@ import {
   isBoolean,
   isPlainObject,
   makeSymbol,
-  isObject
+  isObject,
+  hasOwn
 } from '@intlify/shared'
 import {
   isTranslateFallbackWarn,
@@ -34,7 +35,8 @@ import {
   parseNumberArgs,
   clearNumberFormat,
   NOT_REOSLVED,
-  DevToolsTimelineEvents
+  DevToolsTimelineEvents,
+  handleFlatJson
 } from '@intlify/core-base'
 import { I18nWarnCodes, getWarnMessage } from './warnings'
 import { I18nErrorCodes, createI18nError } from './errors'
@@ -161,6 +163,13 @@ export interface ComposerOptions<Message = VueMessageType> {
    * @defaultValue `{}`
    */
   messages?: LocaleMessages<Message>
+  /**
+   * @remarks
+   * Allow use flat json messages or not
+   *
+   * @defaultValue `false`
+   */
+  flatJson?: boolean
   /**
    * @remarks
    * The datetime formats of localization.
@@ -936,6 +945,7 @@ function defineCoreMissingHandler<Message = VueMessageType>(
 type GetLocaleMessagesOptions<Message = VueMessageType> = {
   messages?: LocaleMessages<Message>
   __i18n?: CustomBlocks<Message>
+  flatJson?: boolean
 }
 
 export function getLocaleMessages<Message = VueMessageType>(
@@ -963,13 +973,16 @@ export function getLocaleMessages<Message = VueMessageType>(
     })
   }
 
-  return ret
-}
+  // handle messages for flat json
+  if (options.flatJson) {
+    for (const key in ret) {
+      if (hasOwn(ret, key)) {
+        handleFlatJson(ret[key])
+      }
+    }
+  }
 
-const hasOwnProperty = Object.prototype.hasOwnProperty
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function hasOwn(obj: object | Array<any>, key: string): boolean {
-  return hasOwnProperty.call(obj, key)
+  return ret
 }
 
 const isNotObjectOrIsArray = (val: unknown) => !isObject(val) || isArray(val)

--- a/packages/vue-i18n/src/legacy.ts
+++ b/packages/vue-i18n/src/legacy.ts
@@ -103,6 +103,13 @@ export interface VueI18nOptions {
   messages?: LocaleMessages<VueMessageType>
   /**
    * @remarks
+   * Allow use flat json messages or not
+   *
+   * @defaultValue `false`
+   */
+  flatJson?: boolean
+  /**
+   * @remarks
    * The datetime formats of localization.
    *
    * @VueI18nSee [Datetime Formatting](../../guide/essentials/datetime)
@@ -964,11 +971,13 @@ function convertComposerOptions<
 
   const datetimeFormats = options.datetimeFormats
   const numberFormats = options.numberFormats
+  const flatJson = options.flatJson
 
   return {
     locale,
     fallbackLocale,
     messages,
+    flatJson,
     datetimeFormats,
     numberFormats,
     missing,

--- a/packages/vue-i18n/test/i18n.test.ts
+++ b/packages/vue-i18n/test/i18n.test.ts
@@ -29,6 +29,33 @@ describe('createI18n', () => {
   })
 })
 
+describe('createI18n with flat json messages', () => {
+  test('legacy mode', () => {
+    const i18n = createI18n({
+      flatJson: true,
+      messages: {
+        en: { 'mainMenu.buttonStart': 'Start!' }
+      }
+    })
+    const messages = i18n.global.messages
+    // @ts-ignore
+    expect(messages.en.mainMenu.buttonStart).toEqual('Start!')
+  })
+
+  test('composition mode', () => {
+    const i18n = createI18n({
+      legacy: false,
+      flatJson: true,
+      messages: {
+        en: { 'mainMenu.buttonStart': 'Start!' }
+      }
+    })
+    const messages = i18n.global.messages.value
+    // @ts-ignore
+    expect(messages.en.mainMenu.buttonStart).toEqual('Start!')
+  })
+})
+
 describe('useI18n', () => {
   let org: any // eslint-disable-line @typescript-eslint/no-explicit-any
   let spy: any // eslint-disable-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Relate to issue #271. Have done in #294, and then we decided this should wait after v9 release.  See this [comment](https://github.com/intlify/vue-i18n-next/pull/306#issuecomment-764208669).
Now v9 have released, I think it's a good time to add this feature.

Note, this time I make this feature optional and not enabled by default.
So I add option `flatJson` in some `interface`. 
Hope I did them in a right way ^_^.

Here is what I have done:
1. add function `handleFlatJson` to `message-resolver`,
function `handleFlatJson` is use to transform flat json to normal json.

2. add optional support for flat json messages to `vue-i18n`.

3. add some tests to `massage-resolver` and `vue-i18n`.

4. move function `hasOwn` to `@intlify/shared`.
