### PR TITLE
fix warning: Missing associated label

### DIFF
--- a/examples/composition/components/translation.html
+++ b/examples/composition/components/translation.html
@@ -33,8 +33,8 @@
 
       <h2>localize with using plural:</h2>
       <form>
-        <label>{{ t('message.quantity', {}, { locale: 'en' }) }}</label>
-        <select v-model="count">
+        <label for="locale-select">{{ t('message.quantity', {}, { locale: 'en' }) }}</label>
+        <select id="locale-select" v-model="count">
           <option value="0">0</option>
           <option value="1">1</option>
           <option value="2">2</option>

--- a/examples/composition/datetime.html
+++ b/examples/composition/datetime.html
@@ -10,8 +10,8 @@
     <div id="app">
       <h1>DateTime Localization for Composition API</h1>
       <form>
-        <label>{{ t('language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en-US">en-US</option>
           <option value="ja-JP">ja-JP</option>
         </select>

--- a/examples/composition/directive/basic.html
+++ b/examples/composition/directive/basic.html
@@ -10,8 +10,8 @@
     <div id="app">
       <form>
         <!-- e.g. string lieteral -->
-        <label v-t="'message.language'"></label>
-        <select v-model="locale">
+        <label for="locale-select" v-t="'message.language'"></label>
+        <select id="locale-select" v-model="locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/composition/formatting/linked.html
+++ b/examples/composition/formatting/linked.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/composition/formatting/list.html
+++ b/examples/composition/formatting/list.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/composition/formatting/literal.html
+++ b/examples/composition/formatting/literal.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/composition/formatting/named.html
+++ b/examples/composition/formatting/named.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/composition/formatting/ruby.html
+++ b/examples/composition/formatting/ruby.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/composition/functions/linked.html
+++ b/examples/composition/functions/linked.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/composition/functions/list.html
+++ b/examples/composition/functions/list.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/composition/functions/named.html
+++ b/examples/composition/functions/named.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/composition/number.html
+++ b/examples/composition/number.html
@@ -18,8 +18,8 @@
     <div id="app">
       <h1>Number Localization for Composition API</h1>
       <form>
-        <label>{{ t('language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en-US">en-US</option>
           <option value="ja-JP">ja-JP</option>
         </select>

--- a/examples/composition/scope/global.html
+++ b/examples/composition/scope/global.html
@@ -10,8 +10,8 @@
     <div id="app">
       <h1>Root</h1>
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/composition/scope/inherit-locale.html
+++ b/examples/composition/scope/inherit-locale.html
@@ -10,8 +10,8 @@
     <div id="app">
       <h1>Root</h1>
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/composition/scope/local.html
+++ b/examples/composition/scope/local.html
@@ -10,8 +10,8 @@
     <div id="app">
       <h1>Root</h1>
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/composition/started.html
+++ b/examples/composition/started.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ t('message.language') }}</label>
-        <select v-model="locale">
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/lazy-loading/vite/src/App.vue
+++ b/examples/lazy-loading/vite/src/App.vue
@@ -11,8 +11,8 @@
         </router-link>
       </div>
       <form class="language">
-        <label>{{ t('labels.language') }}</label>
-        <select v-model="currentLocale">
+        <label for="locale-select">{{ t('labels.language') }}</label>
+        <select id="locale-select" v-model="currentLocale">
           <option
             v-for="optionLocale in supportLocales"
             :key="optionLocale"

--- a/examples/lazy-loading/webpack/src/App.vue
+++ b/examples/lazy-loading/webpack/src/App.vue
@@ -11,8 +11,8 @@
         </router-link>
       </div>
       <form class="language">
-        <label>{{ t('labels.language') }}</label>
-        <select v-model="currentLocale">
+        <label for="locale-select">{{ t('labels.language') }}</label>
+        <select id="locale-select" v-model="currentLocale">
           <option
             v-for="optionLocale in supportLocales"
             :key="optionLocale"

--- a/examples/legacy/components/translation.html
+++ b/examples/legacy/components/translation.html
@@ -31,8 +31,8 @@
 
       <h2>localize with using plural:</h2>
       <form>
-        <label>{{ $t('message.quantity', 'en') }}</label>
-        <select v-model="count">
+        <label for="locale-select">{{ $t('message.quantity', 'en') }}</label>
+        <select id="locale-select" v-model="count">
           <option value="0">0</option>
           <option value="1">1</option>
           <option value="2">2</option>

--- a/examples/legacy/datetime.html
+++ b/examples/legacy/datetime.html
@@ -10,8 +10,8 @@
     <div id="app">
       <h1>DateTime Localization with Legacy API</h1>
       <form>
-        <label>{{ $t('language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en-US">en-US</option>
           <option value="ja-JP">ja-JP</option>
         </select>

--- a/examples/legacy/directive/basic.html
+++ b/examples/legacy/directive/basic.html
@@ -10,8 +10,8 @@
     <div id="app">
       <form>
         <!-- e.g. string lieteral -->
-        <label v-t="'message.language'"></label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select" v-t="'message.language'"></label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/legacy/formatting/linked.html
+++ b/examples/legacy/formatting/linked.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/legacy/formatting/list.html
+++ b/examples/legacy/formatting/list.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/legacy/formatting/literal.html
+++ b/examples/legacy/formatting/literal.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/legacy/formatting/named.html
+++ b/examples/legacy/formatting/named.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/legacy/formatting/ruby.html
+++ b/examples/legacy/formatting/ruby.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/legacy/functions/linked.html
+++ b/examples/legacy/functions/linked.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/legacy/functions/list.html
+++ b/examples/legacy/functions/list.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/legacy/functions/named.html
+++ b/examples/legacy/functions/named.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/legacy/number.html
+++ b/examples/legacy/number.html
@@ -18,8 +18,8 @@
     <div id="app">
       <h1>Number Localization with Legacy API</h1>
       <form>
-        <label>{{ $t('language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en-US">en-US</option>
           <option value="ja-JP">ja-JP</option>
         </select>

--- a/examples/legacy/scope/global.html
+++ b/examples/legacy/scope/global.html
@@ -10,8 +10,8 @@
     <div id="app">
       <h1>Root</h1>
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/legacy/scope/inherit-locale.html
+++ b/examples/legacy/scope/inherit-locale.html
@@ -10,8 +10,8 @@
     <div id="app">
       <h1>Root</h1>
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/legacy/scope/local.html
+++ b/examples/legacy/scope/local.html
@@ -10,8 +10,8 @@
     <div id="app">
       <h1>Root</h1>
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>

--- a/examples/legacy/started.html
+++ b/examples/legacy/started.html
@@ -9,8 +9,8 @@
   <body>
     <div id="app">
       <form>
-        <label>{{ $t('message.language') }}</label>
-        <select v-model="$i18n.locale">
+        <label for="locale-select">{{ $t('message.language') }}</label>
+        <select id="locale-select" v-model="$i18n.locale">
           <option value="en">en</option>
           <option value="ja">ja</option>
         </select>


### PR DESCRIPTION
There is a warning "`Missing associated label` " in some vue file and html file. 
This PR is a fix for it.
See also this [MDN page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)