### PR TITLE
Coherent update from 'best-fit' to 'best fit'

### DIFF
--- a/packages/core-base/src/types.ts
+++ b/packages/core-base/src/types.ts
@@ -43,8 +43,8 @@ export interface CurrencyNumberFormatOptions extends Intl.NumberFormatOptions {
   style: 'currency'
   currency: string // Obligatory if style is 'currency'
   currencyDisplay?: CurrencyDisplay
-  localeMatcher?: 'lookup' | 'best-fit'
-  formatMatcher?: 'basic' | 'best-fit'
+  localeMatcher?: 'lookup' | 'best fit'
+  formatMatcher?: 'basic' | 'best fit'
 }
 
 export type NumberFormatOptions =


### PR DESCRIPTION
Hi, this PR aims to solve a build issue that occurs when you use vue-i18n 9.0.0 with Vite & Vue 3
Here is the error:

```
vue-tsc --noEmit && vite build
node_modules/@intlify/core-base/dist/core-base.d.ts:526:26 - error TS2430: Interface 'SpecificDateTimeFormatOptions' incorrectly extends interface 'DateTimeFormatOptions'.
  Types of property 'localeMatcher' are incompatible.
    Type '"lookup" | "best-fit" | undefined' is not assignable to type '"best fit" | "lookup" | undefined'.
      Type '"best-fit"' is not assignable to type '"best fit" | "lookup" | undefined'.

526 export declare interface SpecificDateTimeFormatOptions extends Intl.DateTimeFormatOptions {
```

On vue-i18n, best-fit was renamed to best-fit in 8.X but the change has not been propagated to core-base

Here is the original PR:
https://github.com/kazupon/vue-i18n/pull/1118