### PR TITLE
Modify some router setups in example projects

### DIFF
--- a/examples/lazy-loading/vite/src/router.ts
+++ b/examples/lazy-loading/vite/src/router.ts
@@ -38,12 +38,12 @@ export function setupRouter(i18n: I18n): Router {
   })
 
   // navigation guards
-  router.beforeEach(async (to, from, next) => {
-    const paramsLocale = (to.params as any).locale as string
+  router.beforeEach(async to => {
+    const paramsLocale = to.params.locale as string
 
     // use locale if paramsLocale is not in SUPPORT_LOCALES
     if (!SUPPORT_LOCALES.includes(paramsLocale)) {
-      return next(`/${locale}`)
+      return `/${locale}`
     }
 
     // load locale messages
@@ -53,8 +53,6 @@ export function setupRouter(i18n: I18n): Router {
 
     // set i18n language
     setI18nLanguage(i18n, paramsLocale)
-
-    return next()
   })
 
   return router

--- a/examples/lazy-loading/webpack/src/router.js
+++ b/examples/lazy-loading/webpack/src/router.js
@@ -33,12 +33,12 @@ export function setupRouter(i18n) {
   })
 
   // navigation guards
-  router.beforeEach(async (to, from, next) => {
+  router.beforeEach(async to => {
     const paramsLocale = to.params.locale
 
     // use locale if paramsLocale is not in SUPPORT_LOCALES
     if (!SUPPORT_LOCALES.includes(paramsLocale)) {
-      return next(`/${locale}`)
+      return `/${locale}`
     }
 
     // load locale messages
@@ -48,8 +48,6 @@ export function setupRouter(i18n) {
 
     // set i18n language
     setI18nLanguage(i18n, paramsLocale)
-
-    return next()
   })
 
   return router


### PR DESCRIPTION
Modify navigation guards:

1. Remove parameter `from` because it's not used
2. Remove parameter `next`， use recommended way by `vue router ` for instead, see also [this](https://next.router.vuejs.org/guide/advanced/navigation-guards.html#global-before-guards)