### PR TITLE
Support passing composer instance to Translation component

### DIFF
--- a/packages/vue-i18n/src/components/DatetimeFormat.ts
+++ b/packages/vue-i18n/src/components/DatetimeFormat.ts
@@ -76,7 +76,9 @@ export const DatetimeFormat = {
   ),
   /* eslint-enable */
   setup(props: DatetimeFormatProps, context: SetupContext): RenderFunction {
-    const i18n = useI18n({ useScope: 'parent' }) as Composer & ComposerInternal
+    const i18n =
+      props.i18n ||
+      (useI18n({ useScope: 'parent' }) as Composer & ComposerInternal)
 
     return renderFormatter<
       FormattableProps<number | Date, Intl.DateTimeFormatOptions>,

--- a/packages/vue-i18n/src/components/NumberFormat.ts
+++ b/packages/vue-i18n/src/components/NumberFormat.ts
@@ -71,7 +71,9 @@ export const NumberFormat = {
   ),
   /* eslint-enable */
   setup(props: NumberFormatProps, context: SetupContext): RenderFunction {
-    const i18n = useI18n({ useScope: 'parent' }) as Composer & ComposerInternal
+    const i18n =
+      props.i18n ||
+      (useI18n({ useScope: 'parent' }) as Composer & ComposerInternal)
 
     return renderFormatter<
       FormattableProps<number, Intl.NumberFormatOptions>,

--- a/packages/vue-i18n/src/components/Translation.ts
+++ b/packages/vue-i18n/src/components/Translation.ts
@@ -27,6 +27,11 @@ export interface TranslationProps extends BaseFormatProps {
    * The Plural Choosing the message number prop
    */
   plural?: number | string
+  /**
+   * @remarks
+   * An existing i18n Composer instance to use for translating
+   */
+  i18n?: Composer
 }
 
 /**

--- a/packages/vue-i18n/src/components/Translation.ts
+++ b/packages/vue-i18n/src/components/Translation.ts
@@ -91,8 +91,7 @@ export const Translation = {
         type: [Number, String],
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         validator: (val: any): boolean => isNumber(val) || !isNaN(val)
-      },
-      i18n: { type: Object }
+      }
     },
     baseFormatProps
   ),

--- a/packages/vue-i18n/src/components/Translation.ts
+++ b/packages/vue-i18n/src/components/Translation.ts
@@ -99,8 +99,9 @@ export const Translation = {
   /* eslint-enable */
   setup(props: TranslationProps, context: SetupContext): RenderFunction {
     const { slots, attrs } = context
-    const i18n = props.i18n ?? useI18n({ useScope: props.scope }) as Composer &
-      ComposerInternal
+    const i18n =
+      props.i18n ??
+      (useI18n({ useScope: props.scope }) as Composer & ComposerInternal)
     const keys = Object.keys(slots).filter(key => key !== '_')
 
     return (): VNodeChild => {

--- a/packages/vue-i18n/src/components/Translation.ts
+++ b/packages/vue-i18n/src/components/Translation.ts
@@ -27,11 +27,6 @@ export interface TranslationProps extends BaseFormatProps {
    * The Plural Choosing the message number prop
    */
   plural?: number | string
-  /**
-   * @remarks
-   * An existing i18n Composer instance to use for translating
-   */
-  i18n?: Composer
 }
 
 /**

--- a/packages/vue-i18n/src/components/Translation.ts
+++ b/packages/vue-i18n/src/components/Translation.ts
@@ -91,14 +91,15 @@ export const Translation = {
         type: [Number, String],
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         validator: (val: any): boolean => isNumber(val) || !isNaN(val)
-      }
+      },
+      i18n: { type: Object }
     },
     baseFormatProps
   ),
   /* eslint-enable */
   setup(props: TranslationProps, context: SetupContext): RenderFunction {
     const { slots, attrs } = context
-    const i18n = useI18n({ useScope: props.scope }) as Composer &
+    const i18n = props.i18n ?? useI18n({ useScope: props.scope }) as Composer &
       ComposerInternal
     const keys = Object.keys(slots).filter(key => key !== '_')
 

--- a/packages/vue-i18n/src/components/Translation.ts
+++ b/packages/vue-i18n/src/components/Translation.ts
@@ -105,7 +105,7 @@ export const Translation = {
   setup(props: TranslationProps, context: SetupContext): RenderFunction {
     const { slots, attrs } = context
     const i18n =
-      props.i18n ??
+      props.i18n ||
       (useI18n({ useScope: props.scope }) as Composer & ComposerInternal)
     const keys = Object.keys(slots).filter(key => key !== '_')
 

--- a/packages/vue-i18n/src/components/base.ts
+++ b/packages/vue-i18n/src/components/base.ts
@@ -1,4 +1,6 @@
 import type { Locale } from '@intlify/core-base'
+import { PropType } from '@vue/runtime-core'
+import { Composer } from '../composer'
 import type { I18nScope } from '../i18n'
 
 export type ComponetI18nScope = Exclude<I18nScope, 'local'>
@@ -37,6 +39,11 @@ export interface BaseFormatProps {
    * If the parent is a global scope, the global scope is used, if it's a local scope, the local scope is used.
    */
   scope?: ComponetI18nScope
+  /**
+   * @remarks
+   * An existing i18n Composer instance to use for translating
+   */
+  i18n?: Composer
 }
 
 export const baseFormatProps = {
@@ -51,5 +58,6 @@ export const baseFormatProps = {
     validator: (val: ComponetI18nScope): boolean =>
       val === 'parent' || val === 'global',
     default: 'parent' as ComponetI18nScope
-  }
+  },
+  i18n: { type: Object as PropType<Composer> }
 }


### PR DESCRIPTION
When using `<i18n-t>` inside a slot of a custom component, it will try to use the scope of the parent component, but because of being inserted into a slot, its parent is now that custom component instead of the original parent component, where the template that used `<i18n-t>` was compiled. As a more concrete example:

1. `Parent` component defines an i18n scope, and a message with key `hello`.
2. `Parent` component uses `Child` component in its template.
3. `Child` component defines a slot named `content` and a new i18n scope (without any messages).
4. `Parent` component uses `<i18n-t keypath="hello">` inside the `content` slot of `Child` component.
5. `<i18n-t>` looks for the message with key `hello` but can't find it in its "parent" component because it's not longer `Parent`, but `Child` instead.

The expected behavior would be for `<i18n-t>` to look for the messages in `Parent` component instead, since that's where it was used in the first place.

I've looked through the source code and can't find a way to somehow trace the parent lookup chain back to where the Translation component was used instead of where it lands through the slot.

The only way I found to make this work was to allow for passing an actual `i18n` composer instance to the `<i18n-t>` component as a prop, so it can be directly used if provided, or fall back to the regular behavior otherwise. This way we can pass the `i18n` composer instance from `Parent` component directly to `<i18n-t>` even if it's placed inside the slot of a custom component that creates its own i18n scope.

Hopefully you find this useful and decide to merge it!