### PR TITLE
Fix __FEATURE_ESM_BUNDLER_WARN__ flag can not be configured

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -72,8 +72,7 @@ module.exports = {
     __ESM_BROWSER__: false,
     __NODE_JS__: true,
     __FEATURE_FULL_INSTALL__: true,
-    __FEATURE_LEGACY_API__: true,
-    __FEATURE_ESM_BUNDLER_WARN__: true
+    __FEATURE_LEGACY_API__: true
   },
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.

--- a/packages/global.d.ts
+++ b/packages/global.d.ts
@@ -15,7 +15,6 @@ declare let __FEATURE_PROD_VUE_DEVTOOLS__: boolean
 declare let __FEATURE_PROD_INTLIFY_DEVTOOLS__: boolean
 declare let __FEATURE_LEGACY_API__: boolean
 declare let __FEATURE_FULL_INSTALL__: boolean
-declare let __FEATURE_ESM_BUNDLER_WARN__: boolean
 
 // for tests
 declare namespace jest {

--- a/packages/vue-i18n/README.md
+++ b/packages/vue-i18n/README.md
@@ -65,10 +65,6 @@ The build will work without configuring these flags, however it is **strongly re
 
 Note: the replacement value **must be boolean literals** and cannot be strings, otherwise the bundler/minifier will not be able to properly evaluate the conditions.
 
-## Other Feature Flags
-
-- `__FEATURE_ESM_BUNDLER_WARN__` (Suppress / Not suppress feature flags recommended warnings in build for `esm-bulder`)
-
 ## :copyright: License
 
 [MIT](http://opensource.org/licenses/MIT)

--- a/packages/vue-i18n/src/misc.ts
+++ b/packages/vue-i18n/src/misc.ts
@@ -36,10 +36,6 @@ export function initFeatureFlags(): void {
     getGlobalThis().__INTLIFY_PROD_DEVTOOLS__ = false
   }
 
-  if (__DEV__ && typeof __FEATURE_ESM_BUNDLER_WARN__ === 'boolean') {
-    needWarn = __FEATURE_ESM_BUNDLER_WARN__
-  }
-
   if (__DEV__ && needWarn) {
     console.warn(
       `You are running the esm-bundler build of vue-i18n. It is recommended to ` +

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -235,7 +235,6 @@ function createReplacePlugin(
     __FEATURE_PROD_INTLIFY_DEVTOOLS__: isBundlerESMBuild
       ? `__INTLIFY_PROD_DEVTOOLS__`
       : false,
-    __FEATURE_ESM_BUNDLER_WARN__: true,
     preventAssignment: false,
     ...(isProduction && isBrowserBuild
       ? {


### PR DESCRIPTION
The `__FEATURE_ESM_BUNDLER_WARN__` is replaced to be `true` in `rollup.config.js`, which make it being impossible to be configured.

Fix #461 