### PR TITLE
fix #383

### DIFF
--- a/packages/core-base/src/datetime.ts
+++ b/packages/core-base/src/datetime.ts
@@ -302,10 +302,18 @@ export function parseDateTimeArgs(
   if (isString(arg1)) {
     // Only allow ISO strings - other date formats are often supported,
     // but may cause different results in different browsers.
-    if (!/\d{4}-\d{2}-\d{2}(T.*)?/.test(arg1)) {
+    const matches = arg1.match(/(\d{4}-\d{2}-\d{2})(T|\s)?(.*)/)
+    if (!matches) {
       throw createCoreError(CoreErrorCodes.INVALID_ISO_DATE_ARGUMENT)
     }
-    value = new Date(arg1)
+    // Some browsers can not parse the iso datetime separated by space,
+    // this is a compromise solution by replace the 'T'/' ' with 'T'
+    const dateTime = matches[3]
+      ? matches[3].trim().startsWith('T')
+        ? `${matches[1].trim()}${matches[3].trim()}`
+        : `${matches[1].trim()}T${matches[3].trim()}`
+      : matches[1].trim()
+    value = new Date(dateTime)
 
     try {
       // This will fail if the date is not valid

--- a/packages/core-base/test/datetime.test.ts
+++ b/packages/core-base/test/datetime.test.ts
@@ -64,6 +64,16 @@ const datetimeFormats: DateTimeFormats<MyDateTimeSchema, 'en-US' | 'ja-JP'> = {
 }
 
 const dt = new Date(Date.UTC(2012, 11, 20, 3, 0, 0))
+const dts = [
+  '2012-12-20 03:00',
+  '2012-12-20  03:00',
+  '2012-12-20 03:00:00',
+  '2012-12-20  03:00:00',
+  '2012-12-20T03:00',
+  '2012-12-20 T03:00',
+  '2012-12-20T03:00:00',
+  '2012-12-20 T03:00:00'
+]
 
 beforeEach(() => {
   registerMessageCompiler(compileToFunction)
@@ -112,6 +122,9 @@ test('key argument', () => {
   })
 
   expect(datetime(ctx, dt, 'short')).toEqual('12/19/2012, 10:00 PM')
+  dts.forEach(dt => {
+    expect(datetime(ctx, dt, 'short')).toEqual('12/19/2012, 10:00 PM')
+  })
 })
 
 test('locale argument', () => {
@@ -127,6 +140,9 @@ test('locale argument', () => {
   })
 
   expect(datetime(ctx, dt, 'short', 'ja-JP')).toEqual('2012/12/20 12:00')
+  dts.forEach(dt => {
+    expect(datetime(ctx, dt, 'short', 'ja-JP')).toEqual('2012/12/20 12:00')
+  })
 })
 
 test('with object argument', () => {
@@ -211,6 +227,9 @@ test(`context fallbackWarn 'false' option`, () => {
   })
 
   expect(datetime(ctx, dt, 'long')).toEqual('2012/12/20 12:00:00')
+  dts.forEach(dt => {
+    expect(datetime(ctx, dt, 'long')).toEqual('2012/12/20 12:00:00')
+  })
   expect(mockWarn).not.toHaveBeenCalled()
 })
 


### PR DESCRIPTION
Some browsers like safari can not successfully parse datetime separated by space(e.g. `2021-05-29 06:00:00`). This PR is a compromise solution by replacing the space(` `) with a `T`.

I tested  on safari and these datetime can be successfully parsed :
```js
{{ $d('2021-02-26 12:58:58', 'long') }}
{{ $d('2021-02-26T12:58:58', 'long') }}
{{ $d('2021-02-26  12:58:58', 'long') }}
{{ $d('2021-02-26  T12:58:58', 'long') }}
{{ $d('2021-02-26', 'long') }}
{{ $d('2021-02-26 12:58', 'long') }}
```

Fix #383 