### PR TITLE
Add number formatting missing type definition

### DIFF
--- a/docs/api/injection.md
+++ b/docs/api/injection.md
@@ -1,5 +1,6 @@
 # Component Injections
 
+
 ## ComponentCustomOptions
 
 Component Custom Properties for Vue I18n
@@ -1183,6 +1184,55 @@ Overloaded `$n`. About details, see the [$n](injection#n-value) remarks.
 | Parameter | Type | Description |
 | --- | --- | --- |
 | value | number | A number value |
+| args | { [key: string]: string } | An argument values |
+
+#### Returns
+
+Formatted value
+
+### $n(value, key, args)
+
+Number formatting
+
+**Signature:**
+```typescript
+$n(value: number, key: string, args: { [key: string]: string }): NumberFormatResult
+```
+
+**Details**
+
+Overloaded `$n`. About details, see the [$n](injection#n-value) remarks.
+
+#### Parameters
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | number | A number value |
+| key | string | A key of number formats |
+| args | { [key: string]: string } | An argument values |
+
+#### Returns
+
+Formatted value
+
+### $n(value, key, locale, args)
+
+Number formatting
+
+**Signature:**
+```typescript
+$n(value: number, key: string, locale: Locale, args: { [key: string]: string }): NumberFormatResult
+```
+
+**Details**
+
+Overloaded `$n`. About details, see the [$n](injection#n-value) remarks.
+
+#### Parameters
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | number | A number value |
+| key | string | A key of number formats |
+| locale | Locale | A locale, override locale that global scope or local scope |
 | args | { [key: string]: string } | An argument values |
 
 #### Returns

--- a/docs/ja/api/injection.md
+++ b/docs/ja/api/injection.md
@@ -1190,6 +1190,55 @@ Overloaded `$n`. About details, see the [$n](injection#n-value) remarks.
 
 Formatted value
 
+### $n(value, key, args)
+
+Number formatting
+
+**Signature:**
+```typescript
+$n(value: number, key: string, args: { [key: string]: string }): NumberFormatResult
+```
+
+**Details**
+
+Overloaded `$n`. About details, see the [$n](injection#n-value) remarks.
+
+#### Parameters
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | number | A number value |
+| key | string | A key of number formats |
+| args | { [key: string]: string } | An argument values |
+
+#### Returns
+
+Formatted value
+
+### $n(value, key, locale, args)
+
+Number formatting
+
+**Signature:**
+```typescript
+$n(value: number, key: string, locale: Locale, args: { [key: string]: string }): NumberFormatResult
+```
+
+**Details**
+
+Overloaded `$n`. About details, see the [$n](injection#n-value) remarks.
+
+#### Parameters
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | number | A number value |
+| key | string | A key of number formats |
+| locale | Locale | A locale, override locale that global scope or local scope |
+| args | { [key: string]: string } | An argument values |
+
+#### Returns
+
+Formatted value
+
 ### $n(value)
 
 Number formatting

--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -1162,6 +1162,33 @@ declare module '@vue/runtime-core' {
      * Overloaded `$n`. About details, see the {@link $n} remarks.
      *
      * @param value - A number value
+     * @param key - A key of number formats
+     * @param args - An argument values
+     *
+     * @returns formatted value
+     */
+    $n(value: number, key: string, args: { [key: string]: string }): NumberFormatResult
+    /**
+     * Number formatting
+     *
+     * @remarks
+     * Overloaded `$n`. About details, see the {@link $n} remarks.
+     *
+     * @param value - A number value
+     * @param key - A key of number formats
+     * @param locale - A locale, optional, override locale that global scope or local scope
+     * @param args - An argument values
+     *
+     * @returns formatted value
+     */
+    $n(value: number, key: string, locale: Locale, args: { [key: string]: string }): NumberFormatResult
+    /**
+     * Number formatting
+     *
+     * @remarks
+     * Overloaded `$n`. About details, see the {@link $n} remarks.
+     *
+     * @param value - A number value
      *
      * @returns formatted value
      */


### PR DESCRIPTION
Fix typing to match usage in examples https://github.com/intlify/vue-i18n-next/blob/master/docs/guide/essentials/number.md

```html
<p>{{ $n(10000, 'currency') }}</p>
<p>{{ $n(10000, 'currency', 'ja-JP') }}</p>
<p>{{ $n(10000, 'currency', 'ja-JP', { useGrouping: false }) }}</p>
<p>{{ $n(987654321, 'currency', { notation: 'compact' }) }}</p>
<p>{{ $n(0.99123, 'percent') }}</p>
<p>{{ $n(0.99123, 'percent', { minimumFractionDigits: 2 }) }}</p>
<p>{{ $n(12.11612345, 'decimal') }}</p>
<p>{{ $n(12145281111, 'decimal', 'ja-JP') }}</p>
```

Linked issue: https://github.com/intlify/vue-i18n-next/issues/540