### PR TITLE
fix: wrong vue-i18n path config in some example projects

### DIFF
--- a/examples/lazy-loading/vite/package.json
+++ b/examples/lazy-loading/vite/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "vue": "^3.0.11",
-    "vue-i18n": "link:../../packages/vue-i18n",
+    "vue-i18n": "link:../../../packages/vue-i18n",
     "vue-router": "^4.0.8"
   },
   "devDependencies": {

--- a/examples/lazy-loading/vite/yarn.lock
+++ b/examples/lazy-loading/vite/yarn.lock
@@ -49,6 +49,18 @@
     "@intlify/shared" "9.1.6"
     "@intlify/vue-devtools" "9.1.6"
 
+"@intlify/core-base@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-9.2.0-alpha.4.tgz#48ae4bf6aa94b7535ffada0187a6b528dbb90723"
+  integrity sha512-8oYUq7cvHJO38V59yHRID/Syds0Jl3CJf+i7Cj3zaixOdR9NbPPXGDM+93Zk9NU/c20+i5Gc6/cDKw4AOhps6A==
+  dependencies:
+    "@intlify/devtools-if" "9.2.0-alpha.4"
+    "@intlify/message-compiler" "9.2.0-alpha.4"
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/runtime" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
+    "@intlify/vue-devtools" "9.2.0-alpha.4"
+
 "@intlify/core@^9.1.0":
   version "9.1.6"
   resolved "https://registry.yarnpkg.com/@intlify/core/-/core-9.1.6.tgz#02215f4f41fa2838923faf51b9d97d6ce055f0a1"
@@ -63,6 +75,13 @@
   dependencies:
     "@intlify/shared" "9.1.6"
 
+"@intlify/devtools-if@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/devtools-if/-/devtools-if-9.2.0-alpha.4.tgz#1a20e2a6facece92a58ba8fa7297c3ede30d180c"
+  integrity sha512-dZ4tyVwAnFwXGrtzcQ13uGV6Sn2JBPTgatl/OyyYm7IZBK0bpCH5yLTxI0LMiaW+dT4FmK25sic2JMnDLTc1ZQ==
+  dependencies:
+    "@intlify/shared" "9.2.0-alpha.4"
+
 "@intlify/message-compiler@9.1.6", "@intlify/message-compiler@^9.1.0":
   version "9.1.6"
   resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-9.1.6.tgz#e3e99165c1e6ecc496211017799ae59e15b05a18"
@@ -72,10 +91,24 @@
     "@intlify/shared" "9.1.6"
     source-map "0.6.1"
 
+"@intlify/message-compiler@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-9.2.0-alpha.4.tgz#0239ebbcbee017abe42c9bcfe704794a425e97c1"
+  integrity sha512-v0BxHoKNpY+eQ5fY4Mthp4AKBqqJGHeiQWB+E3MpSJEzyqSe36b4YmgJjhY9OZ1sKMAmunwPHM1ZAOgBwNhUEg==
+  dependencies:
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
+    source-map "0.6.1"
+
 "@intlify/message-resolver@9.1.6":
   version "9.1.6"
   resolved "https://registry.yarnpkg.com/@intlify/message-resolver/-/message-resolver-9.1.6.tgz#d7493c9f326d5feb0cd8538a6735b648a91d8f2f"
   integrity sha512-UUnbawQa5U9sffd5wRIscqtyY1xWlwJbyfwCLPEWLvBhyAnCwPYlvaHGnnO0CSi0fzJTVwlV9DYzobh3agDeMA==
+
+"@intlify/message-resolver@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/message-resolver/-/message-resolver-9.2.0-alpha.4.tgz#295457dcffa1adf8265741191ddec5a0e70ecc79"
+  integrity sha512-Eg5JQDvLlU6BCOL486QxJMgzSFfZsn6V4IF5zHnxczaPyWfs/X1U02aCySuDqW+a7rKLfsKMimkO+Mo3fnL6Ig==
 
 "@intlify/runtime@9.1.6":
   version "9.1.6"
@@ -86,10 +119,24 @@
     "@intlify/message-resolver" "9.1.6"
     "@intlify/shared" "9.1.6"
 
+"@intlify/runtime@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/runtime/-/runtime-9.2.0-alpha.4.tgz#54184cbe884ab190274a26af632c90a763c77724"
+  integrity sha512-UtE1I3KAk0zj1DOW86zce4hpVJ+S58WU708vNfOYvNmwndJk1o8m89/xJFQyPI2udb1tFc3HM21xy1pbn51gIg==
+  dependencies:
+    "@intlify/message-compiler" "9.2.0-alpha.4"
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
+
 "@intlify/shared@9.1.6", "@intlify/shared@^9.1.0":
   version "9.1.6"
   resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-9.1.6.tgz#d03c9301898d6ddffe2a54c03e7664174fbcdfd9"
   integrity sha512-6MtsKulyfZxdD7OuxjaODjj8QWoHCnLFAk4wkWiHqBCa6UCTC0qXjtEeZ1MxpQihvFmmJZauBUu25EvtngW5qQ==
+
+"@intlify/shared@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-9.2.0-alpha.4.tgz#5fa3a43be81c1c45c4cde73bd75f1c5464dd9b7d"
+  integrity sha512-li8DUeoA4k/C9RILYGaJV4QcLMAXIBtcvyZ/MrvaL9cu5x/DO4SkyiyrM6BnfLoOdyKiC/iEKfTq4zvh2uZYnA==
 
 "@intlify/vite-plugin-vue-i18n@^2.1.2":
   version "2.1.2"
@@ -110,6 +157,15 @@
     "@intlify/message-resolver" "9.1.6"
     "@intlify/runtime" "9.1.6"
     "@intlify/shared" "9.1.6"
+
+"@intlify/vue-devtools@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/vue-devtools/-/vue-devtools-9.2.0-alpha.4.tgz#5172c4d972db01905a907db25d7dd6618dc94c4f"
+  integrity sha512-d6vFfR46Z1c05VvR7ZhZD51rwBHluOcH+6iaE22yVL/fdMq2PFv7mfI5sWucwvShJSMaZA+cYCKZ8/fDl51Jlg==
+  dependencies:
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/runtime" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
@@ -198,6 +254,11 @@
   version "6.0.0-beta.10"
   resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.0.0-beta.10.tgz#f39da7618cee292e39c7274227c34163e30eb3ca"
   integrity sha512-nktQYRnIFrh4DdXiCBjHnsHOMZXDIVcP9qlm/DMfxmjJMtpMGrSZCOKP8j7kDhObNHyqlicwoGLd+a4hf4x9ww==
+
+"@vue/devtools-api@^6.0.0-beta.13":
+  version "6.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.0.0-beta.14.tgz#6ed2d6f8d66a9256c9ad04bfff08309ba87b9723"
+  integrity sha512-44fPrrN1cqcs6bFkT0C+yxTM6PZXLbR+ESh1U1j8UD22yO04gXvxH62HApMjLbS3WqJO/iCNC+CYT+evPQh2EQ==
 
 "@vue/reactivity@3.0.11":
   version "3.0.11"
@@ -816,7 +877,7 @@ vite@^2.3.0:
   optionalDependencies:
     fsevents "~2.3.1"
 
-"vue-i18n@link:../../packages/vue-i18n":
+"vue-i18n@link:../../../packages/vue-i18n":
   version "0.0.0"
   uid ""
 

--- a/examples/tsx/yarn.lock
+++ b/examples/tsx/yarn.lock
@@ -247,61 +247,61 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@intlify/core-base@9.2.0-alpha.3":
-  version "9.2.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-9.2.0-alpha.3.tgz#1f7d1efdee5f02bdc010d40f04608ecbfe076760"
-  integrity sha512-wFN8EmLR6SDpte9ZshONI1N3xzdBzAfcPxUSzN37HjkwEQS/3wxKNcSiJ7i4idK+l7F/7lZ8wnnpcuUbjjdYbw==
+"@intlify/core-base@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-9.2.0-alpha.4.tgz#48ae4bf6aa94b7535ffada0187a6b528dbb90723"
+  integrity sha512-8oYUq7cvHJO38V59yHRID/Syds0Jl3CJf+i7Cj3zaixOdR9NbPPXGDM+93Zk9NU/c20+i5Gc6/cDKw4AOhps6A==
   dependencies:
-    "@intlify/devtools-if" "9.2.0-alpha.3"
-    "@intlify/message-compiler" "9.2.0-alpha.3"
-    "@intlify/message-resolver" "9.2.0-alpha.3"
-    "@intlify/runtime" "9.2.0-alpha.3"
-    "@intlify/shared" "9.2.0-alpha.3"
-    "@intlify/vue-devtools" "9.2.0-alpha.3"
+    "@intlify/devtools-if" "9.2.0-alpha.4"
+    "@intlify/message-compiler" "9.2.0-alpha.4"
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/runtime" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
+    "@intlify/vue-devtools" "9.2.0-alpha.4"
 
-"@intlify/devtools-if@9.2.0-alpha.3":
-  version "9.2.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@intlify/devtools-if/-/devtools-if-9.2.0-alpha.3.tgz#9a812e4c9bb3f4be48868cd442c7c42b8e195a77"
-  integrity sha512-AvjfkBZD8Ef69n573IPYmmsPxI3cw5ieLQlQHlcCHG20shOMhlU1C8gYLmzYV6Ye9licYBtYpAYqHvH3wxRQMQ==
+"@intlify/devtools-if@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/devtools-if/-/devtools-if-9.2.0-alpha.4.tgz#1a20e2a6facece92a58ba8fa7297c3ede30d180c"
+  integrity sha512-dZ4tyVwAnFwXGrtzcQ13uGV6Sn2JBPTgatl/OyyYm7IZBK0bpCH5yLTxI0LMiaW+dT4FmK25sic2JMnDLTc1ZQ==
   dependencies:
-    "@intlify/shared" "9.2.0-alpha.3"
+    "@intlify/shared" "9.2.0-alpha.4"
 
-"@intlify/message-compiler@9.2.0-alpha.3":
-  version "9.2.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-9.2.0-alpha.3.tgz#a7abca0041f4a17c1021a08bb97ebe81320c7a0a"
-  integrity sha512-qgXg5L2YqPZj4sZ+Ohx5AJ2SbTWOejvHs1nbUh5YQC3M8JYvDBFXawp7zrl3hQiedYhR9DcX/oj7cUvKYhAZ2w==
+"@intlify/message-compiler@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-9.2.0-alpha.4.tgz#0239ebbcbee017abe42c9bcfe704794a425e97c1"
+  integrity sha512-v0BxHoKNpY+eQ5fY4Mthp4AKBqqJGHeiQWB+E3MpSJEzyqSe36b4YmgJjhY9OZ1sKMAmunwPHM1ZAOgBwNhUEg==
   dependencies:
-    "@intlify/message-resolver" "9.2.0-alpha.3"
-    "@intlify/shared" "9.2.0-alpha.3"
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
     source-map "0.6.1"
 
-"@intlify/message-resolver@9.2.0-alpha.3":
-  version "9.2.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@intlify/message-resolver/-/message-resolver-9.2.0-alpha.3.tgz#e5de29bcc27897357fdf4de013b416609af409f3"
-  integrity sha512-d9u40BMj8fIRNgx8TdM3MOBAtOXrt1aBlD8JKSEAH/6YOZl0ytZuDliKFqs56bZtAyGgIUvbcoBBdd1WfxVX/w==
+"@intlify/message-resolver@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/message-resolver/-/message-resolver-9.2.0-alpha.4.tgz#295457dcffa1adf8265741191ddec5a0e70ecc79"
+  integrity sha512-Eg5JQDvLlU6BCOL486QxJMgzSFfZsn6V4IF5zHnxczaPyWfs/X1U02aCySuDqW+a7rKLfsKMimkO+Mo3fnL6Ig==
 
-"@intlify/runtime@9.2.0-alpha.3":
-  version "9.2.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@intlify/runtime/-/runtime-9.2.0-alpha.3.tgz#a87c41422d83d8570b6005260a1fe2e5b9eafe2e"
-  integrity sha512-0JOM+EFgQZFp6V72NeFPMr5dYJSNcKc98MfH4+BH/3lfL8h98TIw0QITJd8a3/cu+p4uZAjcBhkW/Rjnd5D6cQ==
+"@intlify/runtime@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/runtime/-/runtime-9.2.0-alpha.4.tgz#54184cbe884ab190274a26af632c90a763c77724"
+  integrity sha512-UtE1I3KAk0zj1DOW86zce4hpVJ+S58WU708vNfOYvNmwndJk1o8m89/xJFQyPI2udb1tFc3HM21xy1pbn51gIg==
   dependencies:
-    "@intlify/message-compiler" "9.2.0-alpha.3"
-    "@intlify/message-resolver" "9.2.0-alpha.3"
-    "@intlify/shared" "9.2.0-alpha.3"
+    "@intlify/message-compiler" "9.2.0-alpha.4"
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
 
-"@intlify/shared@9.2.0-alpha.3":
-  version "9.2.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-9.2.0-alpha.3.tgz#36d629a8ed1953fa142c57aa33ccc61911a4cb97"
-  integrity sha512-WNT3sr6hpL6EyexRXTha8cMI4QRmk29eOw2s79OzahIIztlaDakHtufpFBVHaPj1HwPd0/MeFiOkqbhk1PKKdQ==
+"@intlify/shared@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-9.2.0-alpha.4.tgz#5fa3a43be81c1c45c4cde73bd75f1c5464dd9b7d"
+  integrity sha512-li8DUeoA4k/C9RILYGaJV4QcLMAXIBtcvyZ/MrvaL9cu5x/DO4SkyiyrM6BnfLoOdyKiC/iEKfTq4zvh2uZYnA==
 
-"@intlify/vue-devtools@9.2.0-alpha.3":
-  version "9.2.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@intlify/vue-devtools/-/vue-devtools-9.2.0-alpha.3.tgz#2407e29939332863ae8e05cb7877f0d0ed5cf2a8"
-  integrity sha512-DsYQyzLUDr6EhFLbiogOMdQaE+g0JAvTJ49oRVcqgdUkPoZyF269m8j0gMxKITeU4GwgcV5YvmgdjRPu9xXKyw==
+"@intlify/vue-devtools@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/vue-devtools/-/vue-devtools-9.2.0-alpha.4.tgz#5172c4d972db01905a907db25d7dd6618dc94c4f"
+  integrity sha512-d6vFfR46Z1c05VvR7ZhZD51rwBHluOcH+6iaE22yVL/fdMq2PFv7mfI5sWucwvShJSMaZA+cYCKZ8/fDl51Jlg==
   dependencies:
-    "@intlify/message-resolver" "9.2.0-alpha.3"
-    "@intlify/runtime" "9.2.0-alpha.3"
-    "@intlify/shared" "9.2.0-alpha.3"
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/runtime" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
 
 "@rollup/pluginutils@^4.1.0":
   version "4.1.0"
@@ -397,10 +397,10 @@
     "@vue/compiler-dom" "3.0.11"
     "@vue/shared" "3.0.11"
 
-"@vue/devtools-api@^6.0.0-beta.8":
-  version "6.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.0.0-beta.12.tgz#693ffc77bfb66b080e5c9576abb5786c85470a32"
-  integrity sha512-PtHmAxFmCyCElV7uTWMrXj+fefwn4lCfTtPo9fPw0SK8/7e3UaFl8IL7lnugJmNFfeKQyuTkSoGvTq1uDaRF6Q==
+"@vue/devtools-api@^6.0.0-beta.13":
+  version "6.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.0.0-beta.14.tgz#6ed2d6f8d66a9256c9ad04bfff08309ba87b9723"
+  integrity sha512-44fPrrN1cqcs6bFkT0C+yxTM6PZXLbR+ESh1U1j8UD22yO04gXvxH62HApMjLbS3WqJO/iCNC+CYT+evPQh2EQ==
 
 "@vue/reactivity@3.0.11":
   version "3.0.11"

--- a/examples/type-safe/global-type-definition/package.json
+++ b/examples/type-safe/global-type-definition/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "vue": "^3.0.11",
-    "vue-i18n": "link:../../packages/vue-i18n"
+    "vue-i18n": "link:../../../packages/vue-i18n"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^1.2.2",

--- a/examples/type-safe/global-type-definition/yarn.lock
+++ b/examples/type-safe/global-type-definition/yarn.lock
@@ -20,6 +20,62 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
+"@intlify/core-base@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-9.2.0-alpha.4.tgz#48ae4bf6aa94b7535ffada0187a6b528dbb90723"
+  integrity sha512-8oYUq7cvHJO38V59yHRID/Syds0Jl3CJf+i7Cj3zaixOdR9NbPPXGDM+93Zk9NU/c20+i5Gc6/cDKw4AOhps6A==
+  dependencies:
+    "@intlify/devtools-if" "9.2.0-alpha.4"
+    "@intlify/message-compiler" "9.2.0-alpha.4"
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/runtime" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
+    "@intlify/vue-devtools" "9.2.0-alpha.4"
+
+"@intlify/devtools-if@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/devtools-if/-/devtools-if-9.2.0-alpha.4.tgz#1a20e2a6facece92a58ba8fa7297c3ede30d180c"
+  integrity sha512-dZ4tyVwAnFwXGrtzcQ13uGV6Sn2JBPTgatl/OyyYm7IZBK0bpCH5yLTxI0LMiaW+dT4FmK25sic2JMnDLTc1ZQ==
+  dependencies:
+    "@intlify/shared" "9.2.0-alpha.4"
+
+"@intlify/message-compiler@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-9.2.0-alpha.4.tgz#0239ebbcbee017abe42c9bcfe704794a425e97c1"
+  integrity sha512-v0BxHoKNpY+eQ5fY4Mthp4AKBqqJGHeiQWB+E3MpSJEzyqSe36b4YmgJjhY9OZ1sKMAmunwPHM1ZAOgBwNhUEg==
+  dependencies:
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
+    source-map "0.6.1"
+
+"@intlify/message-resolver@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/message-resolver/-/message-resolver-9.2.0-alpha.4.tgz#295457dcffa1adf8265741191ddec5a0e70ecc79"
+  integrity sha512-Eg5JQDvLlU6BCOL486QxJMgzSFfZsn6V4IF5zHnxczaPyWfs/X1U02aCySuDqW+a7rKLfsKMimkO+Mo3fnL6Ig==
+
+"@intlify/runtime@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/runtime/-/runtime-9.2.0-alpha.4.tgz#54184cbe884ab190274a26af632c90a763c77724"
+  integrity sha512-UtE1I3KAk0zj1DOW86zce4hpVJ+S58WU708vNfOYvNmwndJk1o8m89/xJFQyPI2udb1tFc3HM21xy1pbn51gIg==
+  dependencies:
+    "@intlify/message-compiler" "9.2.0-alpha.4"
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
+
+"@intlify/shared@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-9.2.0-alpha.4.tgz#5fa3a43be81c1c45c4cde73bd75f1c5464dd9b7d"
+  integrity sha512-li8DUeoA4k/C9RILYGaJV4QcLMAXIBtcvyZ/MrvaL9cu5x/DO4SkyiyrM6BnfLoOdyKiC/iEKfTq4zvh2uZYnA==
+
+"@intlify/vue-devtools@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/vue-devtools/-/vue-devtools-9.2.0-alpha.4.tgz#5172c4d972db01905a907db25d7dd6618dc94c4f"
+  integrity sha512-d6vFfR46Z1c05VvR7ZhZD51rwBHluOcH+6iaE22yVL/fdMq2PFv7mfI5sWucwvShJSMaZA+cYCKZ8/fDl51Jlg==
+  dependencies:
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/runtime" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
+
 "@vitejs/plugin-vue@^1.2.2":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-1.2.3.tgz#2e8e008b1cc3a6ad1dfbec75743c7ffd9b4872a6"
@@ -73,6 +129,11 @@
   dependencies:
     "@vue/compiler-dom" "3.0.11"
     "@vue/shared" "3.0.11"
+
+"@vue/devtools-api@^6.0.0-beta.13":
+  version "6.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.0.0-beta.14.tgz#6ed2d6f8d66a9256c9ad04bfff08309ba87b9723"
+  integrity sha512-44fPrrN1cqcs6bFkT0C+yxTM6PZXLbR+ESh1U1j8UD22yO04gXvxH62HApMjLbS3WqJO/iCNC+CYT+evPQh2EQ==
 
 "@vue/reactivity@3.0.11":
   version "3.0.11"
@@ -518,7 +579,7 @@ source-map-js@^0.6.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
-source-map@^0.6.1:
+source-map@0.6.1, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -588,7 +649,7 @@ vite@^2.3.4:
   optionalDependencies:
     fsevents "~2.3.1"
 
-"vue-i18n@link:../../packages/vue-i18n":
+"vue-i18n@link:../../../packages/vue-i18n":
   version "0.0.0"
   uid ""
 

--- a/examples/type-safe/type-annotation/package.json
+++ b/examples/type-safe/type-annotation/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "vue": "^3.0.11",
-    "vue-i18n": "link:../../packages/vue-i18n"
+    "vue-i18n": "link:../../../packages/vue-i18n"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^1.2.2",

--- a/examples/type-safe/type-annotation/yarn.lock
+++ b/examples/type-safe/type-annotation/yarn.lock
@@ -20,6 +20,62 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
+"@intlify/core-base@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-9.2.0-alpha.4.tgz#48ae4bf6aa94b7535ffada0187a6b528dbb90723"
+  integrity sha512-8oYUq7cvHJO38V59yHRID/Syds0Jl3CJf+i7Cj3zaixOdR9NbPPXGDM+93Zk9NU/c20+i5Gc6/cDKw4AOhps6A==
+  dependencies:
+    "@intlify/devtools-if" "9.2.0-alpha.4"
+    "@intlify/message-compiler" "9.2.0-alpha.4"
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/runtime" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
+    "@intlify/vue-devtools" "9.2.0-alpha.4"
+
+"@intlify/devtools-if@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/devtools-if/-/devtools-if-9.2.0-alpha.4.tgz#1a20e2a6facece92a58ba8fa7297c3ede30d180c"
+  integrity sha512-dZ4tyVwAnFwXGrtzcQ13uGV6Sn2JBPTgatl/OyyYm7IZBK0bpCH5yLTxI0LMiaW+dT4FmK25sic2JMnDLTc1ZQ==
+  dependencies:
+    "@intlify/shared" "9.2.0-alpha.4"
+
+"@intlify/message-compiler@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-9.2.0-alpha.4.tgz#0239ebbcbee017abe42c9bcfe704794a425e97c1"
+  integrity sha512-v0BxHoKNpY+eQ5fY4Mthp4AKBqqJGHeiQWB+E3MpSJEzyqSe36b4YmgJjhY9OZ1sKMAmunwPHM1ZAOgBwNhUEg==
+  dependencies:
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
+    source-map "0.6.1"
+
+"@intlify/message-resolver@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/message-resolver/-/message-resolver-9.2.0-alpha.4.tgz#295457dcffa1adf8265741191ddec5a0e70ecc79"
+  integrity sha512-Eg5JQDvLlU6BCOL486QxJMgzSFfZsn6V4IF5zHnxczaPyWfs/X1U02aCySuDqW+a7rKLfsKMimkO+Mo3fnL6Ig==
+
+"@intlify/runtime@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/runtime/-/runtime-9.2.0-alpha.4.tgz#54184cbe884ab190274a26af632c90a763c77724"
+  integrity sha512-UtE1I3KAk0zj1DOW86zce4hpVJ+S58WU708vNfOYvNmwndJk1o8m89/xJFQyPI2udb1tFc3HM21xy1pbn51gIg==
+  dependencies:
+    "@intlify/message-compiler" "9.2.0-alpha.4"
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
+
+"@intlify/shared@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-9.2.0-alpha.4.tgz#5fa3a43be81c1c45c4cde73bd75f1c5464dd9b7d"
+  integrity sha512-li8DUeoA4k/C9RILYGaJV4QcLMAXIBtcvyZ/MrvaL9cu5x/DO4SkyiyrM6BnfLoOdyKiC/iEKfTq4zvh2uZYnA==
+
+"@intlify/vue-devtools@9.2.0-alpha.4":
+  version "9.2.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@intlify/vue-devtools/-/vue-devtools-9.2.0-alpha.4.tgz#5172c4d972db01905a907db25d7dd6618dc94c4f"
+  integrity sha512-d6vFfR46Z1c05VvR7ZhZD51rwBHluOcH+6iaE22yVL/fdMq2PFv7mfI5sWucwvShJSMaZA+cYCKZ8/fDl51Jlg==
+  dependencies:
+    "@intlify/message-resolver" "9.2.0-alpha.4"
+    "@intlify/runtime" "9.2.0-alpha.4"
+    "@intlify/shared" "9.2.0-alpha.4"
+
 "@vitejs/plugin-vue@^1.2.2":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-1.2.3.tgz#2e8e008b1cc3a6ad1dfbec75743c7ffd9b4872a6"
@@ -73,6 +129,11 @@
   dependencies:
     "@vue/compiler-dom" "3.0.11"
     "@vue/shared" "3.0.11"
+
+"@vue/devtools-api@^6.0.0-beta.13":
+  version "6.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.0.0-beta.14.tgz#6ed2d6f8d66a9256c9ad04bfff08309ba87b9723"
+  integrity sha512-44fPrrN1cqcs6bFkT0C+yxTM6PZXLbR+ESh1U1j8UD22yO04gXvxH62HApMjLbS3WqJO/iCNC+CYT+evPQh2EQ==
 
 "@vue/reactivity@3.0.11":
   version "3.0.11"
@@ -518,7 +579,7 @@ source-map-js@^0.6.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
-source-map@^0.6.1:
+source-map@0.6.1, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -588,7 +649,7 @@ vite@^2.3.3:
   optionalDependencies:
     fsevents "~2.3.1"
 
-"vue-i18n@link:../../packages/vue-i18n":
+"vue-i18n@link:../../../packages/vue-i18n":
   version "0.0.0"
   uid ""
 

--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -1167,7 +1167,11 @@ declare module '@vue/runtime-core' {
      *
      * @returns formatted value
      */
-    $n(value: number, key: string, args: { [key: string]: string }): NumberFormatResult
+    $n(
+      value: number,
+      key: string,
+      args: { [key: string]: string }
+    ): NumberFormatResult
     /**
      * Number formatting
      *
@@ -1181,7 +1185,12 @@ declare module '@vue/runtime-core' {
      *
      * @returns formatted value
      */
-    $n(value: number, key: string, locale: Locale, args: { [key: string]: string }): NumberFormatResult
+    $n(
+      value: number,
+      key: string,
+      locale: Locale,
+      args: { [key: string]: string }
+    ): NumberFormatResult
     /**
      * Number formatting
      *


### PR DESCRIPTION
In some example projects, It seems that the relative path of vue-i18n is wrong.
For example, in `examples/lazy-loading/vite/package.json`, Now the configuration is :
```
"vue-i18n": "link:../../packages/vue-i18n"
```
But the correct relative path would be
```
"vue-i18n": "link:../../../packages/vue-i18n"
``` 

This PR fix these wrong conifgs, and update some yarn.lock files.