### PR TITLE
Allow number and boolean in args of number formatting

### DIFF
--- a/docs/api/injection.md
+++ b/docs/api/injection.md
@@ -980,7 +980,7 @@ Datetime formatting
 
 **Signature:**
 ```typescript
-$d(value: number | Date, args: { [key: string]: string }): DateTimeFormatResult;
+$d(value: number | Date, args: { [key: string]: string | boolean | number }): DateTimeFormatResult;
 ```
 
 **Details**
@@ -1173,7 +1173,7 @@ Number formatting
 
 **Signature:**
 ```typescript
-$n(value: number, args: { [key: string]: string }): NumberFormatResult;
+$n(value: number, args: { [key: string]: string | boolean | number }): NumberFormatResult;
 ```
 
 **Details**
@@ -1196,7 +1196,7 @@ Number formatting
 
 **Signature:**
 ```typescript
-$n(value: number, key: string, args: { [key: string]: string }): NumberFormatResult
+$n(value: number, key: string, args: { [key: string]: string | boolean | number }): NumberFormatResult
 ```
 
 **Details**
@@ -1220,7 +1220,7 @@ Number formatting
 
 **Signature:**
 ```typescript
-$n(value: number, key: string, locale: Locale, args: { [key: string]: string }): NumberFormatResult
+$n(value: number, key: string, locale: Locale, args: { [key: string]: string | boolean | number }): NumberFormatResult
 ```
 
 **Details**

--- a/docs/ja/api/injection.md
+++ b/docs/ja/api/injection.md
@@ -980,7 +980,7 @@ Datetime formatting
 
 **Signature:**
 ```typescript
-$d(value: number | Date, args: { [key: string]: string }): DateTimeFormatResult;
+$d(value: number | Date, args: { [key: string]: string | boolean | number }): DateTimeFormatResult;
 ```
 
 **Details**
@@ -1173,7 +1173,7 @@ Number formatting
 
 **Signature:**
 ```typescript
-$n(value: number, args: { [key: string]: string }): NumberFormatResult;
+$n(value: number, args: { [key: string]: string | boolean | number }): NumberFormatResult;
 ```
 
 **Details**
@@ -1196,7 +1196,7 @@ Number formatting
 
 **Signature:**
 ```typescript
-$n(value: number, key: string, args: { [key: string]: string }): NumberFormatResult
+$n(value: number, key: string, args: { [key: string]: string | boolean | number }): NumberFormatResult
 ```
 
 **Details**
@@ -1220,7 +1220,7 @@ Number formatting
 
 **Signature:**
 ```typescript
-$n(value: number, key: string, locale: Locale, args: { [key: string]: string }): NumberFormatResult
+$n(value: number, key: string, locale: Locale, args: { [key: string]: string | boolean | number }): NumberFormatResult
 ```
 
 **Details**

--- a/packages/vue-i18n/src/legacy.ts
+++ b/packages/vue-i18n/src/legacy.ts
@@ -798,7 +798,7 @@ export interface VueI18nDateTimeFormatting<
    *
    * @returns Formatted value
    */
-  (value: number | Date, args: { [key: string]: string }): DateTimeFormatResult
+  (value: number | Date, args: { [key: string]: string | boolean | number }): DateTimeFormatResult
 }
 
 /**
@@ -891,7 +891,7 @@ export interface VueI18nNumberFormatting<
    *
    * @returns Formatted value
    */
-  (value: number, args: { [key: string]: string }): NumberFormatResult
+  (value: number, args: { [key: string]: string | boolean | number }): NumberFormatResult
 }
 
 /**

--- a/packages/vue-i18n/src/legacy.ts
+++ b/packages/vue-i18n/src/legacy.ts
@@ -798,7 +798,10 @@ export interface VueI18nDateTimeFormatting<
    *
    * @returns Formatted value
    */
-  (value: number | Date, args: { [key: string]: string | boolean | number }): DateTimeFormatResult
+  (
+    value: number | Date,
+    args: { [key: string]: string | boolean | number }
+  ): DateTimeFormatResult
 }
 
 /**
@@ -891,7 +894,10 @@ export interface VueI18nNumberFormatting<
    *
    * @returns Formatted value
    */
-  (value: number, args: { [key: string]: string | boolean | number }): NumberFormatResult
+  (
+    value: number,
+    args: { [key: string]: string | boolean | number }
+  ): NumberFormatResult
 }
 
 /**

--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -1154,7 +1154,10 @@ declare module '@vue/runtime-core' {
      *
      * @returns formatted value
      */
-    $n(value: number, args: { [key: string]: string }): NumberFormatResult
+    $n(
+      value: number,
+      args: { [key: string]: string | boolean | number }
+    ): NumberFormatResult
     /**
      * Number formatting
      *
@@ -1170,7 +1173,7 @@ declare module '@vue/runtime-core' {
     $n(
       value: number,
       key: string,
-      args: { [key: string]: string }
+      args: { [key: string]: string | boolean | number }
     ): NumberFormatResult
     /**
      * Number formatting
@@ -1189,7 +1192,7 @@ declare module '@vue/runtime-core' {
       value: number,
       key: string,
       locale: Locale,
-      args: { [key: string]: string }
+      args: { [key: string]: string | boolean | number }
     ): NumberFormatResult
     /**
      * Number formatting


### PR DESCRIPTION
Allow use of boolean and numbers in args to handle args such as:

- useGrouping
- maximumFractionDigits
- minimumFractionDigits
- ....