### PR TITLE
improvement: deprecated __VUE_I18N_PROD_DEVTOOLS__ feature flag

### DIFF
--- a/docs/guide/advanced/optimization.md
+++ b/docs/guide/advanced/optimization.md
@@ -93,7 +93,6 @@ The `esm-bundler` builds now exposes global feature flags that can be overwritte
 
 - `__VUE_I18N_FULL_INSTALL__` (enable/disable, in addition to vue-i18n APIs, components and directives all fully support installation: `true`)
 - `__VUE_I18N_LEGACY_API__` (enable/disable vue-i18n legacy style APIs support, default: `true`)
-- `__VUE_I18N_PROD_DEVTOOLS__` (enable/disable vue-devtools support in production, default: `false`)
 - `__INTLIFY_PROD_DEVTOOLS__` (enable/disable `@intlify/devtools` support in production, default: `false`)
 
 :::warning NOTICE

--- a/packages/size-check-vue-i18n/rollup.config.js
+++ b/packages/size-check-vue-i18n/rollup.config.js
@@ -28,7 +28,6 @@ const config = {
       __VUE_PROD_DEVTOOLS__: false,
       __VUE_I18N_LEGACY_API__: false,
       __VUE_I18N_FULL_INSTALL__: false,
-      __VUE_I18N_PROD_DEVTOOLS__: false,
       __INTLIFY_PROD_DEVTOOLS__: false,
       'process.env.NODE_ENV': JSON.stringify('production')
     }),

--- a/packages/vue-i18n/README.md
+++ b/packages/vue-i18n/README.md
@@ -52,7 +52,6 @@ The `esm-bundler` builds now exposes global feature flags that can be overwritte
 
 - `__VUE_I18N_FULL_INSTALL__` (enable/disable, in addition to vue-i18n APIs, components and directives all fully support installation: `true`)
 - `__VUE_I18N_LEGACY_API__` (enable/disable vue-i18n legacy style APIs support, default: `true`)
-- `__VUE_I18N_PROD_DEVTOOLS__` (enable/disable vue-devtools support in production, default: `false`)
 - `__INTLIFY_PROD_DEVTOOLS__` (enable/disable `@intlify/devtools` support in production, default: `false`)
 
 > NOTE: `__INTLIFY_PROD_DEVTOOLS__` flag is experimental, and `@intlify/devtools` is WIP yet.

--- a/packages/vue-i18n/src/misc.ts
+++ b/packages/vue-i18n/src/misc.ts
@@ -27,11 +27,6 @@ export function initFeatureFlags(): void {
     getGlobalThis().__VUE_I18N_LEGACY_API__ = true
   }
 
-  if (typeof __FEATURE_PROD_VUE_DEVTOOLS__ !== 'boolean') {
-    needWarn = true
-    getGlobalThis().__VUE_I18N_PROD_DEVTOOLS__ = false
-  }
-
   if (typeof __FEATURE_PROD_INTLIFY_DEVTOOLS__ !== 'boolean') {
     getGlobalThis().__INTLIFY_PROD_DEVTOOLS__ = false
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -230,7 +230,7 @@ function createReplacePlugin(
       ? `__VUE_I18N_LEGACY_API__`
       : true,
     __FEATURE_PROD_VUE_DEVTOOLS__: isBundlerESMBuild
-      ? `__VUE_I18N_PROD_DEVTOOLS__`
+      ? `__VUE_PROD_DEVTOOLS__`
       : false,
     __FEATURE_PROD_INTLIFY_DEVTOOLS__: isBundlerESMBuild
       ? `__INTLIFY_PROD_DEVTOOLS__`


### PR DESCRIPTION
Internally, it was changed from `__VUE_I18N_PROD_DEVTOOLS__` to `__VUE_PROD_DEVTOOLS__`.
This makes it unnecessary to specify `__VUE_I18N_PROD_DEVTOOLS__` in bundlers such as vite, since it works together with vue optimization.