### PR TITLE
Fix type-safe example warning

### DIFF
--- a/examples/type-safe/global-type-definition/src/components/HelloWorld.vue
+++ b/examples/type-safe/global-type-definition/src/components/HelloWorld.vue
@@ -13,6 +13,7 @@ export default defineComponent({
   setup() {
     // use global scope
     const { t, d, n } = useI18n({
+      useScope: 'global',
       inheritLocale: true
     })
     return { t, d, n }

--- a/examples/type-safe/global-type-definition/vite.config.ts
+++ b/examples/type-safe/global-type-definition/vite.config.ts
@@ -3,5 +3,9 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()]
+  plugins: [vue()],
+  define: {
+    __VUE_I18N_FULL_INSTALL__: true,
+    __VUE_I18N_LEGACY_API__: true
+  }
 })

--- a/examples/type-safe/type-annotation/vite.config.ts
+++ b/examples/type-safe/type-annotation/vite.config.ts
@@ -3,5 +3,9 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()]
+  plugins: [vue()],
+  define: {
+    __VUE_I18N_FULL_INSTALL__: true,
+    __VUE_I18N_LEGACY_API__: true
+  }
 })


### PR DESCRIPTION
1. Fix `not found key` warning in `examples/type-safe/global-type-definition`,   see [this implementation](https://github.com/intlify/vue-i18n-next/blob/6eaf91ae864f128676d5f6000986ee8ae31f77cf/packages/vue-i18n-core/src/i18n.ts#L599)
```ts
  const scope: I18nScope = isEmptyObject(options)
    ? ('__i18n' in instance.type)
      ? 'local'
      : 'global'
    : !options.useScope
      ? 'local'
      : options.useScope
```
It will set scope to `local` when `options` is not empty and `options.useScope` was not config. So in this case we should explicit use global scope.


2. Fix  `feature flag` warning in `examples/type-safe/global-type-definition` and `examples/type-safe/type-annotation` by config flags in `vite.config.ts`