### PR TITLE
Fixed a type in the Composition API documentation (it's -> its)

### DIFF
--- a/docs/guide/advanced/composition.md
+++ b/docs/guide/advanced/composition.md
@@ -31,7 +31,7 @@ const i18n = VueI18n.createI18n({
 You can set `legacy: false` to allow Vue I18n to switch the API mode, from Legacy API mode to Composition API mode.
 
 :::tip NOTE
-The following properties of i18n instance created by `createI18n` change it’s behavior:
+The following properties of i18n instance created by `createI18n` change its behavior:
 
 - `mode` property: `"legacy"` to `"composition"`
 - `global` property: VueI18n instance to Composer instance


### PR DESCRIPTION
In the page about the Composition API, there's an "it's" that should be spelled "its" instead. This was fixed.