### PR TITLE
fix: remove terser option pure_getters: true, avoid wrong tree-shaking

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -326,8 +326,7 @@ function createMinifiedConfig(format) {
       terser({
         module: /^esm/.test(format),
         compress: {
-          ecma: 2015,
-          pure_getters: true
+          ecma: 2015
         }
       })
     ]


### PR DESCRIPTION
See this [comment](https://github.com/intlify/vue-i18n-next/issues/736#issuecomment-947275731) in #736