### PR TITLE
docs: update process.env.NODE_ENV

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -103,7 +103,7 @@ Global builds are not [UMD](https://github.com/umdjs/umd) builds. They are built
 
 - **`vue-i18n(.runtime).esm-bundler.js`**:
   - For use with bundlers like `webpack`, `rollup` and `parcel`
-  - Leaves prod/dev branches with `process\.env\.NODE_ENV` guards (must be replaced by bundler)
+  - Leaves prod/dev branches with `process.env.NODE_ENV` guards (must be replaced by bundler)
   - Does not ship minified builds (to be done together with the rest of the code after bundling)
   - Imports dependencies (e.g. `@intlify/core-base`, `@intlify/message-compiler`)
     - Imported dependencies are also `esm-bundler` builds and will in turn import their dependencies (e.g. `@intlify/message-compiler` imports `@intlify/shared`)
@@ -125,4 +125,4 @@ If you use `vue-i18n.runtime.esm-bundler.js`, you will need to precompile all lo
 - **`vue-i18n.cjs(.prod).js`**:
   - For use in Node.js via `require()`
   - If you bundle your app with webpack with `target: 'node'` and properly externalize `vue-i18n`, this is the build that will be loaded
-  - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process\.env\.NODE_ENV`
+  - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process.env.NODE_ENV`


### PR DESCRIPTION
It seems we do not need to escape `\.` in `<code></code`.