### PR TITLE
fix: fix "pnpm dev" failure

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -21,8 +21,9 @@ import { fuzzyMatchTarget } from './utils'
 import minimist from 'minimist'
 ;(async () => {
   const args = minimist(process.argv.slice(2))
-  const targets = await fuzzyMatchTarget(args._)
-  const target = args._.length ? targets[0] : 'vue-i18n'
+  const target = args._.length
+    ? (await fuzzyMatchTarget(args._))[0]
+    : 'vue-i18n'
   const formats = args.formats || args.f
   const sourceMap = args.sourcemap || args.s
   const { stdout } = await execa('git', ['rev-parse', 'HEAD'])


### PR DESCRIPTION
Per [contribution guide](https://github.com/intlify/vue-i18n-next/blob/e94386aa6b0999991582bc2051673314360d14a0/.github/CONTRIBUTING.md?plain=1#L135), running `pnpm dev` should build vue-i18n package, but it actually causes a failure:

```bash
> node -r esbuild-register scripts/dev.ts


   ERROR  Target  not found!

 ELIFECYCLE  Command failed with exit code 1.
FAIL: 1
```

This seems because fuzzyMatchTarget throws an error when no command line argument is passed in.