### PR TITLE
fix: typo in the layout slot

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -44,7 +44,7 @@ export default {
     </template>
     <template #home-hero>
     </template>
-    <template #home-featuers>
+    <template #home-features>
     </template>
     <template #home-footer>
     </template>


### PR DESCRIPTION
Fix a typo in a slot of the default theme's `<Layout/>` component.