### PR TITLE
Fix the id of the app's container element

### DIFF
--- a/docs/guide/advanced/directive.md
+++ b/docs/guide/advanced/directive.md
@@ -87,7 +87,7 @@ app.mount('#object-syntax')
 Templates:
 
 ```html
-<div id="app">
+<div id="object-syntax">
   <!-- literal -->
   <p v-t="{ path: 'message.hi', args: { name: 'kazupon' } }"></p>
   <!-- data binding via data -->

--- a/docs/ja/guide/advanced/directive.md
+++ b/docs/ja/guide/advanced/directive.md
@@ -87,7 +87,7 @@ app.mount('#object-syntax')
 Templates:
 
 ```html
-<div id="app">
+<div id="object-syntax">
   <!-- literal -->
   <p v-t="{ path: 'message.hi', args: { name: 'kazupon' } }"></p>
   <!-- data binding via data -->


### PR DESCRIPTION
https://vue-i18n.intlify.dev/guide/advanced/directive.html#object-syntax

In the JavaScript it's `app.mount('#object-syntax')`, but in the template it's `<div id="app">`. The two do not match.