### PR TITLE
fix: slot resolving in render function

### DIFF
--- a/packages/vue-i18n-core/src/components/Translation.ts
+++ b/packages/vue-i18n-core/src/components/Translation.ts
@@ -106,9 +106,9 @@ export const Translation = /* #__PURE__*/ /* defineComponent */ {
         useScope: props.scope as 'global' | 'parent',
         __useComponent: true
       }) as Composer & ComposerInternal)
-    const keys = Object.keys(slots).filter(key => key !== '_')
 
     return (): VNodeChild => {
+      const keys = Object.keys(slots).filter(key => key !== '_')
       const options = {} as TranslateOptions
       if (props.locale) {
         options.locale = props.locale


### PR DESCRIPTION
We change the Slots keys to be resolved in the render function, which in Vue 3 can be resolved in the setup function, but in Vue 2.7 can only be resolved in the render function

related #1062 