### PR TITLE
fix: rename file extension of ESM modules

### DIFF
--- a/packages/vue-i18n/package.json
+++ b/packages/vue-i18n/package.json
@@ -53,10 +53,10 @@
   "buildOptions": {
     "name": "VueI18n",
     "formats": [
-      "esm-bundler.mjs",
-      "esm-bundler-runtime.mjs",
-      "esm-browser.mjs",
-      "esm-browser-runtime.mjs",
+      "esm-bundler",
+      "esm-bundler-runtime",
+      "esm-browser",
+      "esm-browser-runtime",
       "cjs",
       "global",
       "global-runtime"

--- a/packages/vue-i18n/package.json
+++ b/packages/vue-i18n/package.json
@@ -53,10 +53,10 @@
   "buildOptions": {
     "name": "VueI18n",
     "formats": [
-      "esm-bundler",
-      "esm-bundler-runtime",
-      "esm-browser",
-      "esm-browser-runtime",
+      "esm-bundler.mjs",
+      "esm-bundler-runtime.mjs",
+      "esm-browser.mjs",
+      "esm-browser-runtime.mjs",
       "cjs",
       "global",
       "global-runtime"
@@ -66,7 +66,7 @@
     ".": {
       "import": {
         "node": "./index.mjs",
-        "default": "./dist/vue-i18n.esm-bundler.js"
+        "default": "./dist/vue-i18n.esm-bundler.mjs"
       },
       "require": "./index.js"
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,11 +26,11 @@ let hasTSChecked = false
 
 const outputConfigs = {
   'esm-bundler': {
-    file: resolve(`dist/${name}.esm-bundler.js`),
+    file: resolve(`dist/${name}.esm-bundler.mjs`),
     format: `es`
   },
   'esm-browser': {
-    file: resolve(`dist/${name}.esm-browser.js`),
+    file: resolve(`dist/${name}.esm-browser.mjs`),
     format: `es`
   },
   cjs: {
@@ -43,11 +43,11 @@ const outputConfigs = {
   },
   // runtime-only builds, for '@intlify/core' and 'vue-i18n' package only
   'esm-bundler-runtime': {
-    file: resolve(`dist/${name}.runtime.esm-bundler.js`),
+    file: resolve(`dist/${name}.runtime.esm-bundler.mjs`),
     format: `es`
   },
   'esm-browser-runtime': {
-    file: resolve(`dist/${name}.runtime.esm-browser.js`),
+    file: resolve(`dist/${name}.runtime.esm-browser.mjs`),
     format: 'es'
   },
   'global-runtime': {


### PR DESCRIPTION
Since the `vue-i18n` package is not declared as a module the imported files are not recognized as modules. Thus, it leads to errors because the `import` statement is not allowed in CommonJS files. This PR will rename the file extensions so NodeJS loads the files correctly as modules. 

This is a breaking change because all the documents refer to a file ending with `.js` so I would like to hear your opinion what you think.