### PR TITLE
fix(package): allow vue 2.7

### DIFF
--- a/packages/vue-i18n/package.json
+++ b/packages/vue-i18n/package.json
@@ -45,7 +45,7 @@
     "@intlify/devtools-if": "9.2.2"
   },
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^2.7.0 || ^3.0.0"
   },
   "engines": {
     "node": ">= 14"


### PR DESCRIPTION
This library should be usable with Vue 2.7 as well.

Missing: `vue.Fragment`, `vue.Text`, `vue.createVNode` support. My question:
- could those usages be checked to only run in Vue 3?
- should one use i18n-bridge instead?