### PR TITLE
fix typo in legacy API

### DIFF
--- a/packages/vue-i18n-core/src/legacy.ts
+++ b/packages/vue-i18n-core/src/legacy.ts
@@ -537,7 +537,7 @@ export interface VueI18nTranslation<
  * Resolve locale message translation functions for VueI18n legacy interfaces
  *
  * @remarks
- * This is the interface for {@link VueI18n}. This interfce is an alias of {@link ComposerResolveLocaleMessageTranslation}.
+ * This is the interface for {@link VueI18n}. This interface is an alias of {@link ComposerResolveLocaleMessageTranslation}.
  *
  * @VueI18nLegacy
  */


### PR DESCRIPTION
In VueI18nResolveLocaleMessageTranslation