### PR TITLE
fix: correct typo in `TranslateVNodeSymbol`

### DIFF
--- a/packages/vue-i18n-core/src/components/Translation.ts
+++ b/packages/vue-i18n-core/src/components/Translation.ts
@@ -1,6 +1,6 @@
 import { h } from 'vue'
 import { isNumber, isString, isObject } from '@intlify/shared'
-import { TransrateVNodeSymbol } from '../symbols'
+import { TranslateVNodeSymbol } from '../symbols'
 import { useI18n } from '../i18n'
 import { baseFormatProps } from './base'
 import { assign } from '@intlify/shared'
@@ -118,7 +118,7 @@ export const Translation = /* #__PURE__*/ /* defineComponent */ {
       }
       const arg = getInterpolateArg(context, keys)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const children = (i18n as any)[TransrateVNodeSymbol](
+      const children = (i18n as any)[TranslateVNodeSymbol](
         props.keypath,
         arg,
         options

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -39,7 +39,7 @@ import { VueDevToolsTimelineEvents } from '@intlify/vue-devtools'
 import { I18nWarnCodes, getWarnMessage } from './warnings'
 import { I18nErrorCodes, createI18nError } from './errors'
 import {
-  TransrateVNodeSymbol,
+  TranslateVNodeSymbol,
   DatetimePartsSymbol,
   NumberPartsSymbol,
   EnableEmitter,
@@ -1683,7 +1683,7 @@ export interface Composer<
  * @internal
  */
 export interface ComposerInternal {
-  __transrateVNode(...args: unknown[]): VNodeArrayChildren
+  __translateVNode(...args: unknown[]): VNodeArrayChildren
   __numberParts(...args: unknown[]): string | Intl.NumberFormatPart[]
   __datetimeParts(...args: unknown[]): string | Intl.DateTimeFormatPart[]
   __enableEmitter?: (emitter: VueDevToolsEmitter) => void
@@ -2188,8 +2188,8 @@ export function createComposer(options: any = {}, VueI18nLegacy?: any): any {
     type: 'vnode'
   } as MessageProcessor<VNode>
 
-  // transrateVNode, using for `i18n-t` component
-  function transrateVNode(...args: unknown[]): VNodeArrayChildren {
+  // translateVNode, using for `i18n-t` component
+  function translateVNode(...args: unknown[]): VNodeArrayChildren {
     return wrapWithDeps<VNode, VNodeArrayChildren>(
       context => {
         let ret: unknown
@@ -2208,7 +2208,7 @@ export function createComposer(options: any = {}, VueI18nLegacy?: any): any {
       () => parseTranslateArgs(...args),
       'translate',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      root => (root as any)[TransrateVNodeSymbol](...args),
+      root => (root as any)[TranslateVNodeSymbol](...args),
       key => [createTextNode(key as string)],
       val => isArray(val)
     )
@@ -2504,7 +2504,7 @@ export function createComposer(options: any = {}, VueI18nLegacy?: any): any {
     ;(composer as any).setNumberFormat = setNumberFormat
     ;(composer as any).mergeNumberFormat = mergeNumberFormat
     ;(composer as any)[InejctWithOption] = options.__injectWithOption
-    ;(composer as any)[TransrateVNodeSymbol] = transrateVNode
+    ;(composer as any)[TranslateVNodeSymbol] = translateVNode
     ;(composer as any)[DatetimePartsSymbol] = datetimeParts
     ;(composer as any)[NumberPartsSymbol] = numberParts
   }

--- a/packages/vue-i18n-core/src/symbols.ts
+++ b/packages/vue-i18n-core/src/symbols.ts
@@ -1,7 +1,7 @@
 import { makeSymbol } from '@intlify/shared'
 
-export const TransrateVNodeSymbol =
-  /* #__PURE__*/ makeSymbol('__transrateVNode')
+export const TranslateVNodeSymbol =
+  /* #__PURE__*/ makeSymbol('__translateVNode')
 export const DatetimePartsSymbol = /* #__PURE__*/ makeSymbol('__datetimeParts')
 export const NumberPartsSymbol = /* #__PURE__*/ makeSymbol('__numberParts')
 export const EnableEmitter = /* #__PURE__*/ makeSymbol('__enableEmitter')

--- a/packages/vue-i18n-core/test/__snapshots__/composer.test.ts.snap
+++ b/packages/vue-i18n-core/test/__snapshots__/composer.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`__transrateVNode missing 1`] = `
+exports[`__translateVNode missing 1`] = `
 Array [
   Object {
     "__v_isVNode": true,

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -18,7 +18,7 @@ import {
   VueMessageType
 } from '../src/composer'
 import {
-  TransrateVNodeSymbol,
+  TranslateVNodeSymbol,
   NumberPartsSymbol,
   DatetimePartsSymbol
 } from '../src/symbols'
@@ -1514,7 +1514,7 @@ describe('__i18n', () => {
   })
 })
 
-describe('__transrateVNode', () => {
+describe('__translateVNode', () => {
   test('basic', () => {
     const composer = createComposer({
       locale: 'en',
@@ -1525,7 +1525,7 @@ describe('__transrateVNode', () => {
       }
     })
     expect(
-      (composer as any)[TransrateVNodeSymbol]('hello', {
+      (composer as any)[TranslateVNodeSymbol]('hello', {
         name: createVNode(Text, null, 'kazupon', 0)
       })
     ).toMatchObject([
@@ -1543,7 +1543,7 @@ describe('__transrateVNode', () => {
       }
     })
     expect(
-      (composer as any)[TransrateVNodeSymbol]('hello', {
+      (composer as any)[TranslateVNodeSymbol]('hello', {
         name: createVNode(Text, null, 'kazupon', 0)
       })
     ).toMatchSnapshot()


### PR DESCRIPTION
I'm not entirely sure whether the error shown is due to the typos, but nevertheless worth correcting :)

(occured when using the `<i18n-t>` component with `@nuxtjs/i18n@next`)

![image](https://user-images.githubusercontent.com/48835293/202670980-f37e3212-996d-42f6-b2fe-cf863c4cf51c.png)