### PR TITLE
Docs: search for "useI18n" yields non-existing /ja/api/composition.html 

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -52,6 +52,9 @@ export default defineConfig({
       appId: 'BH4D9OD16A',
       apiKey: '3a9e93ba1069de0ece2ae100daf8f6ea',
       indexName: 'vue-i18n',
+      searchParameters : {
+        facetFilters: ['language:en-US']
+      },
       // algoliaOptions: { facetFilters: ['tags:guide,api'] }
     },
 


### PR DESCRIPTION
There is a search issue on the doc site (https://vue-i18n.intlify.dev/) 
The non-English page is excluded by adding the configuration parameter of Algolia.

Issue 
https://github.com/intlify/vue-i18n-next/issues/1218


 
