### PR TITLE
docs: Add space before link text

### DIFF
--- a/docs/guide/integrations/nuxt3.md
+++ b/docs/guide/integrations/nuxt3.md
@@ -8,7 +8,7 @@ The following is a tutorial on setting up a Nuxt 3 application from the initial 
 This Nuxt3 application is set up in this tutorial doesn't support advanced i18n, such as URL (routing), SEO with `head` tag, and `lang` attribute in `html`tag.
 
 Support for Nuxt 3 & Nuxt Bridge in [nuxtjs/i18n](https://i18n.nuxtjs.org/) is currently under development with Nuxt community.
-You can check out the status of development and docs at[v8.i18n.nuxtjs.org](https://v8.i18n.nuxtjs.org/)
+You can check out the status of development and docs at [v8.i18n.nuxtjs.org](https://v8.i18n.nuxtjs.org/)
 
 See the GitHub Discussion [here](https://github.com/nuxt-community/i18n-module/discussions/1287)
 :::


### PR DESCRIPTION
Insert a space before the link text in order for the translation tool to translate it correctly.

|before|after|
|---|---|
|<img width="515" alt="スクリーンショット 2023-02-19 23 47 29" src="https://user-images.githubusercontent.com/20086673/219955691-ea0f5e0e-6fe4-456e-bd2d-b6fe75eb8d54.png">|<img width="515" alt="スクリーンショット 2023-02-19 23 49 22" src="https://user-images.githubusercontent.com/20086673/219955699-2f1f570c-5e5c-446b-9a66-020f2e0a71d7.png">|
