### PR TITLE
fix: isPlainObject incorrectly identifies objects wrapped in a Proxy object in Safari 10

### DIFF
--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -151,8 +151,11 @@ export const objectToString = Object.prototype.toString
 export const toTypeString = (value: unknown): string =>
   objectToString.call(value)
 
-export const isPlainObject = (val: unknown): val is object =>
-  toTypeString(val) === '[object Object]'
+export const isPlainObject = (val: unknown): val is object => {
+  if (!isObject(val)) return false
+  const proto = Object.getPrototypeOf(val)
+  return proto === null || proto.constructor === Object
+}
 
 // for converting list and named values to displayed strings.
 export const toDisplayString = (val: unknown): string => {


### PR DESCRIPTION
Hi there!

I noticed that in Safari 10, the `isPlainObject` method used in `vue-i18n` can lead to an issue where objects wrapped in a `Proxy` object, such as those returned by the `ref` method in Vue, are incorrectly identified as non-plain objects. This can result in an empty `messages` object and the inability to retrieve localized content.

To address this issue, I propose changing the `isPlainObject` method used in `vue-i18n` to use the `Object.prototype.constructor` property to check if an object is a plain object. This method is more reliable and performs well in all browsers, including Safari 10.

Here's the updated code for the `isPlainObject` method:

```javascript
function isPlainObject(obj) {
  if (typeof obj !== 'object' || obj === null) return false
  const proto = Object.getPrototypeOf(obj)
  return proto === null || proto.constructor === Object
}
```

This change should resolve the issue in Safari 10 and ensure that objects wrapped in a `Proxy` object are correctly identified as plain objects.

Please let me know if you have any questions or concerns. Thanks for considering this PR!

Best regards

closes(#1378)