### PR TITLE
fix(#1327): Fixed package.json exports to work with moduleResolution "bundle"

### DIFF
--- a/packages/vue-i18n/package.json
+++ b/packages/vue-i18n/package.json
@@ -63,23 +63,18 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/vue-i18n.d.ts",
-      "import": "./dist/vue-i18n.mjs",
-      "browser": "./dist/vue-i18n.esm-browser.js",
-      "node": {
-        "import": {
-          "production": "./dist/vue-i18n.node.mjs",
-          "development": "./dist/vue-i18n.mjs",
-          "default": "./dist/vue-i18n.mjs"
-        },
-        "require": {
-          "production": "./dist/vue-i18n.prod.cjs",
-          "development": "./dist/vue-i18n.cjs",
-          "default": "./index.js"
-        }
+      "import": {
+        "types": "./dist/vue-i18n.d.ts",
+        "node": "./index.mjs",
+        "default": "./dist/vue-i18n.esm-bundler.js"
+      },
+      "require": {
+        "types": "./dist/vue-i18n.d.cts",
+        "default": "./index.js"
       }
     },
     "./dist/*": "./dist/*",
+    "./index.mjs": "./index.mjs",
     "./package.json": "./package.json"
   },
   "funding": "https://github.com/sponsors/kazupon",


### PR DESCRIPTION
Fixes #1327 as proposed by [RebeccaStevens](https://github.com/RebeccaStevens) [here](https://github.com/intlify/vue-i18n-next/issues/1327#issuecomment-1484658084) as well as #1384.

With Typescript 5 & [vuejs/tsconfig 0.3.2](https://github.com/vuejs/tsconfig), `moduleResolution: 'bundle'` has become standard.

However, this package does not properly define typings in package.json which results in type-checking to fail & the following warning:
```
TS7016: Could not find a declaration file for module 'vue-i18n'. '/.../node_modules/vue-i18n/dist/vue-i18n.esm-bundler.js' implicitly has an 'any' type.
  There are types at '/.../node_modules/vue-i18n/dist/vue-i18n.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vue-i18n' library may need to update its package.json or typings.
```

I'm not completely sure if the `node` and `browser` exports still serve any value, might wanna include them again if you see a reason for them.
