### PR TITLE
Fix typo

### DIFF
--- a/docs/.ja/api/component.md
+++ b/docs/.ja/api/component.md
@@ -31,7 +31,7 @@ If specified, the global scope or the locale of the parent scope of the target c
 
 **Signature:**
 ```typescript
-scope?: ComponetI18nScope;
+scope?: ComponentI18nScope;
 ```
 
 **Details**

--- a/packages/vue-i18n-core/src/components/base.ts
+++ b/packages/vue-i18n-core/src/components/base.ts
@@ -3,7 +3,7 @@ import { Composer } from '../composer'
 import type { I18nScope } from '../i18n'
 import type { Locale } from '@intlify/core-base'
 
-export type ComponetI18nScope = Exclude<I18nScope, 'local'>
+export type ComponentI18nScope = Exclude<I18nScope, 'local'>
 
 /**
  * BaseFormat Props for Components that is offered Vue I18n
@@ -38,7 +38,7 @@ export interface BaseFormatProps {
    *
    * If the parent is a global scope, the global scope is used, if it's a local scope, the local scope is used.
    */
-  scope?: ComponetI18nScope
+  scope?: ComponentI18nScope
   /**
    * @remarks
    * A composer instance with an existing scope.
@@ -59,9 +59,9 @@ export const baseFormatProps = {
     type: String,
     // NOTE: avoid https://github.com/microsoft/rushstack/issues/1050
     validator: (
-      val: Exclude<I18nScope, 'local'> /* ComponetI18nScope */
+      val: Exclude<I18nScope, 'local'> /* ComponentI18nScope */
     ): boolean => val === 'parent' || val === 'global',
-    default: 'parent' as Exclude<I18nScope, 'local'> /* ComponetI18nScope */
+    default: 'parent' as Exclude<I18nScope, 'local'> /* ComponentI18nScope */
   },
   i18n: {
     type: Object

--- a/packages/vue-i18n-core/src/components/index.ts
+++ b/packages/vue-i18n-core/src/components/index.ts
@@ -1,4 +1,4 @@
-export { ComponetI18nScope, BaseFormatProps } from './base'
+export { ComponentI18nScope, BaseFormatProps } from './base'
 export { FormattableProps } from './formatRenderer'
 export { Translation, I18nT, TranslationProps } from './Translation'
 export { NumberFormat, I18nN, NumberFormatProps } from './NumberFormat'

--- a/packages/vue-i18n-core/src/index.ts
+++ b/packages/vue-i18n-core/src/index.ts
@@ -94,7 +94,7 @@ export {
   DatetimeFormatProps,
   FormattableProps,
   BaseFormatProps,
-  ComponetI18nScope
+  ComponentI18nScope
 } from './components'
 export { vTDirective, TranslationDirective } from './directive'
 export { I18nPluginOptions } from './plugin'

--- a/packages/vue-i18n/src/index.ts
+++ b/packages/vue-i18n/src/index.ts
@@ -108,7 +108,7 @@ export {
   DatetimeFormatProps,
   FormattableProps,
   BaseFormatProps,
-  ComponetI18nScope
+  ComponentI18nScope
 } from '../../vue-i18n-core/src/components'
 export {
   vTDirective,

--- a/packages/vue-i18n/src/runtime.ts
+++ b/packages/vue-i18n/src/runtime.ts
@@ -103,7 +103,7 @@ export {
   DatetimeFormatProps,
   FormattableProps,
   BaseFormatProps,
-  ComponetI18nScope
+  ComponentI18nScope
 } from '../../vue-i18n-core/src/components'
 export {
   vTDirective,


### PR DESCRIPTION
This is imho a breaking change, don't know if i should deprecate the wrong spelling also and leave both versions? 
But then which Version to use in the BaseFormatProps ?

Suggestions/Changes welcome