### PR TITLE
fix: drop node v14

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,10 +22,12 @@ It is of course fine to use non-English language, when you open a PR to translat
 - Work in the `src` folder and **DO NOT** checkin `dist` in the commits.
 
 - If adding new feature:
+
   - Add accompanying test case.
   - Provide convincing reason to add this feature. Ideally you should open a suggestion issue first and have it greenlighted before working on it.
 
 - If fixing a bug:
+
   - Provide detailed description of the bug in the PR. Live demo preferred.
   - Add appropriate test coverage if applicable.
 
@@ -34,6 +36,7 @@ It is of course fine to use non-English language, when you open a PR to translat
 - Make sure `npm test` passes. (see [development setup](#development-setup))
 
 ### Work Step Example
+
 - Fork the repository from [intlify/vue-i18n-next](https://github.com/intlify/vue-i18n-next) !
 - Create your topic branch from `master`: `git branch my-new-topic origin/master`
 - Add codes and pass tests !
@@ -43,7 +46,7 @@ It is of course fine to use non-English language, when you open a PR to translat
 
 ## Development Setup
 
-You will need [Node.js](http://nodejs.org) **version 12+**, and [PNPM](https://pnpm.io).
+You will need [Node.js](http://nodejs.org) **version 16+**, and [PNPM](https://pnpm.io).
 
 We also recommend installing [ni](https://github.com/antfu/ni) to help switching between repos using different package managers. `ni` also provides the handy `nr` command which running npm scripts easier.
 
@@ -52,7 +55,6 @@ After cloning the repo, run:
 ```bash
 $ pnpm i # install the dependencies of the project
 ```
-
 
 A high level overview of tools used:
 

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "typescript": "^4.9.4"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "private": true,
   "gitHooks": {

--- a/packages/core-base/package.json
+++ b/packages/core-base/package.json
@@ -39,7 +39,7 @@
     "@intlify/vue-devtools": "workspace:*"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "buildOptions": {
     "name": "IntlifyCoreBase",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "@intlify/core-base": "workspace:*"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "buildOptions": {
     "name": "IntlifyCore",

--- a/packages/devtools-if/package.json
+++ b/packages/devtools-if/package.json
@@ -33,7 +33,7 @@
     "@intlify/shared": "workspace:*"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "buildOptions": {
     "name": "IntlifyDevToolsIf",

--- a/packages/message-compiler/package.json
+++ b/packages/message-compiler/package.json
@@ -37,7 +37,7 @@
     "source-map": "0.6.1"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "buildOptions": {
     "name": "IntlifyMessageCompiler",

--- a/packages/petite-vue-i18n/package.json
+++ b/packages/petite-vue-i18n/package.json
@@ -47,7 +47,7 @@
     "vue": "^3.0.0"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "buildOptions": {
     "name": "PetiteVueI18n",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,7 +30,7 @@
   "module": "dist/shared.mjs",
   "types": "dist/shared.d.ts",
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "buildOptions": {
     "name": "IntlifyShared",

--- a/packages/vue-devtools/package.json
+++ b/packages/vue-devtools/package.json
@@ -34,7 +34,7 @@
     "@intlify/shared": "workspace:*"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "buildOptions": {
     "name": "IntlifyVueDevtools",

--- a/packages/vue-i18n-bridge/package.json
+++ b/packages/vue-i18n-bridge/package.json
@@ -49,7 +49,7 @@
     "@vue/composition-api": "^1.0.0-rc.1"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "buildOptions": {
     "name": "VueI18nBridge",

--- a/packages/vue-i18n-core/package.json
+++ b/packages/vue-i18n-core/package.json
@@ -47,7 +47,7 @@
     "vue": "^3.0.0"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "buildOptions": {
     "name": "IntlifyVueI18nCore",

--- a/packages/vue-i18n/package.json
+++ b/packages/vue-i18n/package.json
@@ -47,7 +47,7 @@
     "vue": "^3.0.0"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "buildOptions": {
     "name": "VueI18n",


### PR DESCRIPTION
No related issues.

Node versions specified in the codebase and docs are inconsistent.
This PR is to unify Node versions to 16 for 2 reasons:

- only Node 16 is tested in CI (i.e. `.github/workflows/ci.yml`)
- the associated commit to `.github/workflows/ci.yml` is newer than other places (e.g. commit to `package.json`)

⚠️ This is my very first PR for this repository, so I might be missing something.