### PR TITLE
fix: Resolve the message in components which was rendered with slots, for about `<i18n-t>`, `<i18n-n>` and `<i18n-d>`

### DIFF
--- a/packages/vue-i18n-core/src/i18n.ts
+++ b/packages/vue-i18n-core/src/i18n.ts
@@ -1063,10 +1063,14 @@ function getParentComponentInstance(
   if (target == null) {
     return null
   }
-  // if `useComponent: true` will be specified, we get lexical scope owner instance for use-case slots
-  return !useComponent
-    ? target.parent
-    : (target.vnode as any).ctx || target.parent // eslint-disable-line @typescript-eslint/no-explicit-any
+  if (!__BRIDGE__) {
+    // if `useComponent: true` will be specified, we get lexical scope owner instance for use-case slots
+    return !useComponent
+      ? target.parent
+      : (target.vnode as any).ctx || target.parent // eslint-disable-line @typescript-eslint/no-explicit-any
+  } else {
+    return target.parent
+  }
 }
 
 function setupLifeCycle(

--- a/packages/vue-i18n-core/src/i18n.ts
+++ b/packages/vue-i18n-core/src/i18n.ts
@@ -1021,7 +1021,10 @@ function getComposer(
 ): Composer | null {
   let composer: Composer | null = null
   const root = target.root
-  let current: ComponentInternalInstance | null = target.parent
+  let current: ComponentInternalInstance | null = getParentComponentInstance(
+    target,
+    useComponent
+  )
   while (current != null) {
     const i18nInternal = i18n as unknown as I18nInternal
     if (i18n.mode === 'composition') {
@@ -1051,6 +1054,19 @@ function getComposer(
     current = current.parent
   }
   return composer
+}
+
+function getParentComponentInstance(
+  target: ComponentInternalInstance | null,
+  useComponent = false
+) {
+  if (target == null) {
+    return null
+  }
+  // if `useComponent: true` will be specified, we get lexical scope owner instance for use-case slots
+  return !useComponent
+    ? target.parent
+    : (target.vnode as any).ctx || target.parent // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 function setupLifeCycle(

--- a/packages/vue-i18n-core/test/components/Translation.test.ts
+++ b/packages/vue-i18n-core/test/components/Translation.test.ts
@@ -189,7 +189,7 @@ test('scope', async () => {
 `
   })
 
-  const Root = defineComponent({
+  const App = defineComponent({
     components: {
       Container
     },
@@ -208,7 +208,7 @@ test('scope', async () => {
     template: `<Container>`
   })
 
-  const wrapper = await mount(Root, i18n)
+  const wrapper = await mount(App, i18n)
 
   expect(wrapper.html()).toEqual(`this is rootthis is global`)
 })


### PR DESCRIPTION
closes #729 
closes #1392 