### PR TITLE
Fix #1475: Typo in documentation when referring to translation component

### DIFF
--- a/docs/.ja/api/component.md
+++ b/docs/.ja/api/component.md
@@ -257,9 +257,9 @@ See the following items for property about details
 ```html
 <div id="app">
   <!-- ... -->
-  <i18n path="term" tag="label" for="tos">
+  <i18n-t path="term" tag="label" for="tos">
     <a :href="url" target="_blank">{{ $t('tos') }}</a>
-  </i18n>
+  </i18n-t>
   <!-- ... -->
 </div>
 ```


### PR DESCRIPTION
### Fixed #1475

- Typo in documentation when referring to translation component.
- Removed the translation component referred to i18n and updated it to i18n-t

