### PR TITLE
fix: drop componentInstanceCreatedListener

### DIFF
--- a/docs/.ja/api/legacy.md
+++ b/docs/.ja/api/legacy.md
@@ -1363,25 +1363,6 @@ The list of available locales in messages in lexical order.
 
 `[]`
 
-### componentInstanceCreatedListener
-
-**Signature:**
-```typescript
-componentInstanceCreatedListener?: ComponentInstanceCreatedListener;
-```
-
-**Details**
-
-A handler for getting notified when component-local instance was created.
-
-The handler gets called with new and old (root) VueI18n instances.
-
-This handler is useful when extending the root VueI18n instance and wanting to also apply those extensions to component-local instance.
-
-**Default Value**
-
-`null`
-
 ### datetimeFormats
 
 **Signature:**

--- a/packages/petite-vue-i18n/src/index.ts
+++ b/packages/petite-vue-i18n/src/index.ts
@@ -79,7 +79,6 @@ export {
   VueI18nDateTimeFormatting,
   VueI18nNumberFormatting,
   VueI18nResolveLocaleMessageTranslation,
-  ComponentInstanceCreatedListener,
   VueI18nExtender
 } from '../../vue-i18n-core/src/legacy'
 export {

--- a/packages/petite-vue-i18n/src/runtime.ts
+++ b/packages/petite-vue-i18n/src/runtime.ts
@@ -76,7 +76,6 @@ export {
   VueI18nDateTimeFormatting,
   VueI18nNumberFormatting,
   VueI18nResolveLocaleMessageTranslation,
-  ComponentInstanceCreatedListener,
   VueI18nExtender
 } from '../../vue-i18n-core/src/legacy'
 export {

--- a/packages/vue-i18n-bridge/src/index.ts
+++ b/packages/vue-i18n-bridge/src/index.ts
@@ -89,7 +89,6 @@ export {
   VueI18nDateTimeFormatting,
   VueI18nNumberFormatting,
   VueI18nResolveLocaleMessageTranslation,
-  ComponentInstanceCreatedListener,
   VueI18nExtender
 } from '../../vue-i18n-core/src/legacy'
 export {

--- a/packages/vue-i18n-bridge/src/runtime.ts
+++ b/packages/vue-i18n-bridge/src/runtime.ts
@@ -86,7 +86,6 @@ export {
   VueI18nDateTimeFormatting,
   VueI18nNumberFormatting,
   VueI18nResolveLocaleMessageTranslation,
-  ComponentInstanceCreatedListener,
   VueI18nExtender
 } from '../../vue-i18n-core/src/legacy'
 export {

--- a/packages/vue-i18n-core/src/index.ts
+++ b/packages/vue-i18n-core/src/index.ts
@@ -66,7 +66,6 @@ export {
   VueI18nDateTimeFormatting,
   VueI18nNumberFormatting,
   VueI18nResolveLocaleMessageTranslation,
-  ComponentInstanceCreatedListener,
   VueI18nExtender
 } from './legacy'
 export {

--- a/packages/vue-i18n-core/src/legacy.ts
+++ b/packages/vue-i18n-core/src/legacy.ts
@@ -80,13 +80,6 @@ export interface Formatter {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   interpolate(message: string, values: any, path: string): Array<any> | null
 }
-export type ComponentInstanceCreatedListener = <
-  Messages extends Record<string, any>
->(
-  target: VueI18n<Messages>,
-  global: VueI18n<Messages>
-) => void
-
 export type VueI18nExtender = (vueI18n: VueI18n) => Disposer | undefined
 
 /**
@@ -330,17 +323,6 @@ export interface VueI18nOptions<
    * @defaultValue `true`
    */
   sync?: boolean
-  /**
-   * @remarks
-   * A handler for getting notified when component-local instance was created.
-   *
-   * The handler gets called with new and old (root) VueI18n instances.
-   *
-   * This handler is useful when extending the root VueI18n instance and wanting to also apply those extensions to component-local instance.
-   *
-   * @defaultValue `null`
-   */
-  componentInstanceCreatedListener?: ComponentInstanceCreatedListener
   /**
    * @remarks
    * A message resolver to resolve [`messages`](legacy#messages).
@@ -1314,9 +1296,6 @@ export interface VueI18nInternal<
   NumberFormats extends Record<string, any> = {}
 > {
   __composer: Composer<Messages, DateTimeFormats, NumberFormats>
-  __onComponentInstanceCreated(
-    target: VueI18n<Messages, DateTimeFormats, NumberFormats>
-  ): void
   __enableEmitter?: (emitter: VueDevToolsEmitter) => void
   __disableEmitter?: () => void
   __extender?: VueI18nExtender
@@ -1796,14 +1775,6 @@ export function createVueI18n(options: any = {}, VueI18nLegacy?: any): any {
         __DEV__ &&
           warn(getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_GET_CHOICE_INDEX))
         return -1
-      },
-
-      // for internal
-      __onComponentInstanceCreated(target: VueI18n<{}>): void {
-        const { componentInstanceCreatedListener } = options
-        if (componentInstanceCreatedListener) {
-          componentInstanceCreatedListener(target, vueI18n)
-        }
       }
     }
 

--- a/packages/vue-i18n-core/src/mixins/next.ts
+++ b/packages/vue-i18n-core/src/mixins/next.ts
@@ -98,11 +98,6 @@ export function defineMixin(
         adjustI18nResources(composer, options as ComposerOptions, options)
       }
 
-      // TODO: remove `__onComponentInstanceCreated`, because nuxt i18n v8 does not require it.
-      ;(vuei18n as unknown as VueI18nInternal).__onComponentInstanceCreated(
-        this.$i18n
-      )
-
       // defines vue-i18n legacy APIs
       this.$t = (...args: unknown[]): TranslateResult => this.$i18n.t(...args)
       this.$rt = (...args: unknown[]): TranslateResult => this.$i18n.rt(...args)

--- a/packages/vue-i18n-core/test/i18n.test.ts
+++ b/packages/vue-i18n-core/test/i18n.test.ts
@@ -1431,7 +1431,7 @@ describe('Composer & VueI18n extend hooking', () => {
         })
         return { foo }
       },
-      template: '<p class="child">{{ foo }}</p><GrandChild >'
+      template: '<p class="child">{{ foo }}</p><GrandChild />'
     })
 
     const App = defineComponent({

--- a/packages/vue-i18n-core/test/mixin.test.ts
+++ b/packages/vue-i18n-core/test/mixin.test.ts
@@ -222,25 +222,6 @@ test('$i18n', async () => {
   expect((vm.$i18n! as VueI18n).t('hello')).toEqual('hello!')
 })
 
-test('VueI18n componentInstanceCreatedListener option', async () => {
-  const componentInstanceCreatedListener = vi.fn()
-  const i18n = createI18n({
-    legacy: true,
-    locale: 'en',
-    componentInstanceCreatedListener
-  })
-
-  const App = defineComponent({
-    template: '<br/>',
-    i18n: {
-      locale: 'ja'
-    }
-  })
-  await mount(App, i18n)
-
-  expect(componentInstanceCreatedListener).toHaveBeenCalled()
-})
-
 test.skip('beforeDestroy', async () => {
   const i18n = createI18n({
     legacy: true,

--- a/packages/vue-i18n/src/index.ts
+++ b/packages/vue-i18n/src/index.ts
@@ -89,7 +89,6 @@ export {
   VueI18nDateTimeFormatting,
   VueI18nNumberFormatting,
   VueI18nResolveLocaleMessageTranslation,
-  ComponentInstanceCreatedListener,
   VueI18nExtender
 } from '../../vue-i18n-core/src/legacy'
 export {

--- a/packages/vue-i18n/src/runtime.ts
+++ b/packages/vue-i18n/src/runtime.ts
@@ -86,7 +86,6 @@ export {
   VueI18nDateTimeFormatting,
   VueI18nNumberFormatting,
   VueI18nResolveLocaleMessageTranslation,
-  ComponentInstanceCreatedListener,
   VueI18nExtender
 } from '../../vue-i18n-core/src/legacy'
 export {


### PR DESCRIPTION
`componentInstanceCreatedListener` is an I/F for nuxt i18n. nuxt i18n v8 no longer needs this I/F. And this I/F is undocument. So remove it.