### PR TITLE
docs: add vite-plugin-vue-i18n support vite version to warning notice

### DIFF
--- a/docs/guide/advanced/optimization.md
+++ b/docs/guide/advanced/optimization.md
@@ -103,7 +103,7 @@ Intlify project is providing [`vite-plugin-vue-i18n`](https://github.com/intlify
 If you do a production build, Vue I18n will automatically bundle the runtime only module
 
 :::warning NOTICE
-This plugin will be deprecated in the near future, because we can replace `@intlify/unplugin-vue-i18n`.
+This plugin support until `Vite 3`. If you would like to use on `Vite 4`, please use `@intlify/unplugin-vue-i18n`
 :::
 
 #### Install plugin


### PR DESCRIPTION
Avoid reader using wrong plugin when compiled and minified for production on vite 4.