### PR TITLE
fix(core-base): `isMessageAST` more strictly

### DIFF
--- a/packages/core-base/src/translate.ts
+++ b/packages/core-base/src/translate.ts
@@ -55,7 +55,7 @@ export const isMessageFunction = <T>(val: unknown): val is MessageFunction<T> =>
   isFunction(val)
 
 export const isMessageAST = (val: unknown): val is ResourceNode =>
-  isObject(val) && val.type === 0 && 'body' in val
+  isObject(val) && val.type === 0 && ('body' in val || 'b' in val)
 
 /**
  *  # translate

--- a/packages/core-base/test/translate.test.ts
+++ b/packages/core-base/test/translate.test.ts
@@ -13,7 +13,7 @@ vi.mock('@intlify/shared', async () => {
 })
 
 import { createCoreContext as context, NOT_REOSLVED } from '../src/context'
-import { translate } from '../src/translate'
+import { translate, isMessageAST } from '../src/translate'
 import { CoreErrorCodes, errorMessages } from '../src/errors'
 import {
   registerMessageCompiler,
@@ -989,6 +989,26 @@ describe('AST passing', () => {
       }
     })
     expect(translate(ctx, 'hi')).toEqual('hi kazupon !')
+  })
+})
+
+describe('isMessageAST', () => {
+  describe('basic AST', () => {
+    test('should be true', () => {
+      expect(isMessageAST({ type: 0, body: '' })).toBe(true)
+    })
+  })
+
+  describe('minify AST', () => {
+    test('should be true', () => {
+      expect(isMessageAST({ type: 0, b: '' })).toBe(true)
+    })
+  })
+
+  describe('not message compiler AST format', () => {
+    test('should be false', () => {
+      expect(isMessageAST({ b: '' })).toBe(false)
+    })
   })
 })
 


### PR DESCRIPTION
I noticed this issue when I've created [this PR](https://github.com/intlify/bundle-tools/pull/287)