### PR TITLE
Update All devDependencies Nuxt 3 Minimal Starter Example to Latest Versions

### DIFF
--- a/examples/frameworks/nuxt3/package.json
+++ b/examples/frameworks/nuxt3/package.json
@@ -7,8 +7,8 @@
     "preview": "nuxt preview"
   },
   "devDependencies": {
-    "@intlify/unplugin-vue-i18n": "^0.2.1",
-    "nuxt": "3.4.3",
-    "vue-i18n": "^9.1.10"
+    "@intlify/unplugin-vue-i18n": "^1.0.1",
+    "nuxt": "^3.7.1",
+    "vue-i18n": "^9.3.0"
   }
 }


### PR DESCRIPTION
This pull request updates all devDependencies of Nuxt 3 Minimal Starter Example to their latest versions, enhancing stability, security, and performance:

- @intlify/unplugin-vue-i18n to "^1.0.1"
- nuxt to "^3.7.1"
- vue-i18n to "^9.3.0"