### PR TITLE
fix: support runtime module for node.js

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -139,11 +139,14 @@ If you use `vue-i18n.runtime.esm-bundler.js`, you will need to precompile all lo
 :new: 9.3+
 :::
 
-- **`vue-i18n.node.mjs`**:
+- **`vue-i18n(.runtime).node.mjs`**:
   - For ES Moudles usage in Node.js
   - For use in Node.js via `import`
   - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process.env`<wbr/>`.NODE_ENV`
+  - This module is proxy module of `vue-i18n(.runtime).mjs`
+    - **`vue-i18n.runtime.node.mjs`**: is runtime only. proxy `vue-i18n.runtime.mjs`.
+    - **`vue-i18n.node.mjs`**: includes the runtime compiler. proxy `vue-i18n.mjs`.
 
 :::tip NOTE
-ES Modules will be the future of the Node.js module system. The `vue-i18n.cjs(.prod).js` will be deprecated in the future. We recommend you would use `vue-i18n.node.mjs`.
+ES Modules will be the future of the Node.js module system. The `vue-i18n.cjs(.prod).js` will be deprecated in the future. We recommend you would use `vue-i18n(.runtime).node.mjs`.
 :::

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -47,8 +47,8 @@ The intlify core module for i18n
   - For use in Node.js via `import`
   - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process.env.NODE_ENV`
   - This module is proxy module of `core(.runtime).mjs`
-    - **`core.runtime.node.mjs`**: is runtime only. proxy `core.runtime.mjs`.
-    - **`core.node.mjs`**: includes the runtime compiler. proxy `core.mjs`.
+    - **`core.runtime.node.mjs`**: is runtime only. proxy `core.runtime.mjs`
+    - **`core.node.mjs`**: includes the runtime compiler. proxy `core.mjs`
 
 > NOTE: ES Modules will be the future of the Node.js module system. The `core.cjs(.prod).js` will be deprecated in the future. We recommend you would use `core(.runtime).node.mjs`. 9.3+
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -42,12 +42,15 @@ The intlify core module for i18n
   - If you bundle your app with webpack with `target: 'node'` and properly externalize `@intlify/core`, this is the build that will be loaded
   - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process.env.NODE_ENV`
 
-- **`core.node.mjs`**:
+- **`core(.runtime).node.mjs`**:
   - For ES Moudles usage in Node.js
   - For use in Node.js via `import`
   - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process.env`<wbr/>`.NODE_ENV`
+  - This module is proxy module of `core(.runtime).mjs`
+    - **`core.runtime.node.mjs`**: is runtime only. proxy `core.runtime.mjs`.
+    - **`core.node.mjs`**: includes the runtime compiler. proxy `core.mjs`.
 
-> NOTE: ES Modules will be the future of the Node.js module system. The `core.cjs(.prod).js` will be deprecated in the future. We recommend you would use `core.node.mjs`. 9.3+
+> NOTE: ES Modules will be the future of the Node.js module system. The `core.cjs(.prod).js` will be deprecated in the future. We recommend you would use `core(.runtime).node.mjs`. 9.3+
 
 
 ## :copyright: License

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -45,7 +45,7 @@ The intlify core module for i18n
 - **`core(.runtime).node.mjs`**:
   - For ES Moudles usage in Node.js
   - For use in Node.js via `import`
-  - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process.env`<wbr/>`.NODE_ENV`
+  - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process.env.NODE_ENV`
   - This module is proxy module of `core(.runtime).mjs`
     - **`core.runtime.node.mjs`**: is runtime only. proxy `core.runtime.mjs`.
     - **`core.node.mjs`**: includes the runtime compiler. proxy `core.mjs`.

--- a/packages/vue-i18n/README.md
+++ b/packages/vue-i18n/README.md
@@ -47,7 +47,7 @@ Internationalization plugin for Vue.js
 - **`vue-i18n(.runtime).node.mjs`**:
   - For ES Moudles usage in Node.js
   - For use in Node.js via `import`
-  - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process.env`<wbr/>`.NODE_ENV`
+  - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process.env.NODE_ENV`
   - This module is proxy module of `vue-i18n(.runtime).mjs`
     - **`vue-i18n.runtime.node.mjs`**: is runtime only. proxy `vue-i18n.runtime.mjs`.
     - **`vue-i18n.node.mjs`**: includes the runtime compiler. proxy `vue-i18n.mjs`.

--- a/packages/vue-i18n/README.md
+++ b/packages/vue-i18n/README.md
@@ -49,8 +49,8 @@ Internationalization plugin for Vue.js
   - For use in Node.js via `import`
   - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process.env.NODE_ENV`
   - This module is proxy module of `vue-i18n(.runtime).mjs`
-    - **`vue-i18n.runtime.node.mjs`**: is runtime only. proxy `vue-i18n.runtime.mjs`.
-    - **`vue-i18n.node.mjs`**: includes the runtime compiler. proxy `vue-i18n.mjs`.
+    - **`vue-i18n.runtime.node.mjs`**: is runtime only. proxy `vue-i18n.runtime.mjs`
+    - **`vue-i18n.node.mjs`**: includes the runtime compiler. proxy `vue-i18n.mjs`
 
 > NOTE: ES Modules will be the future of the Node.js module system. The `vue-i18n.cjs(.prod).js` will be deprecated in the future. We recommend you would use `vue-i18n(.runtime).node.mjs`. 9.3+
 

--- a/packages/vue-i18n/README.md
+++ b/packages/vue-i18n/README.md
@@ -44,13 +44,15 @@ Internationalization plugin for Vue.js
   - If you bundle your app with webpack with `target: 'node'` and properly externalize `vue-i18n`, this is the build that will be loaded
   - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process.env.NODE_ENV`
 
-- **`vue-i18n.node.mjs`**:
+- **`vue-i18n(.runtime).node.mjs`**:
   - For ES Moudles usage in Node.js
   - For use in Node.js via `import`
   - The dev/prod files are pre-built, but the appropriate file is automatically required based on `process.env`<wbr/>`.NODE_ENV`
+  - This module is proxy module of `vue-i18n(.runtime).mjs`
+    - **`vue-i18n.runtime.node.mjs`**: is runtime only. proxy `vue-i18n.runtime.mjs`.
+    - **`vue-i18n.node.mjs`**: includes the runtime compiler. proxy `vue-i18n.mjs`.
 
-
-> NOTE: ES Modules will be the future of the Node.js module system. The `vue-i18n.cjs(.prod).js` will be deprecated in the future. We recommend you would use `vue-i18n.node.mjs`. 9.3+
+> NOTE: ES Modules will be the future of the Node.js module system. The `vue-i18n.cjs(.prod).js` will be deprecated in the future. We recommend you would use `vue-i18n(.runtime).node.mjs`. 9.3+
 
 
 ## For Bundler feature flags

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -274,26 +274,37 @@ function createConfig(format, _output, plugins = []) {
           console.log(`created stub ${pc.bold(`dist/${stub}`)}`)
 
           // add the node specific version
-          if (format === 'mjs') {
+          if (format === 'mjs' || format === 'mjs-runtime') {
             // NOTE:
             //  https://github.com/vuejs/router/issues/1516
             //  https://github.com/vuejs/router/commit/53f720622aa273e33c05517fa917cdcfbfba52bc
-            if (name === 'vue-i18n' || name === 'vue-i18n-bridge' || name === 'petite-vue-i18n') {
-              const outfile = `dist/${stub}`.replace('esm-bundler.js', 'node.mjs')
+            if (
+              name === 'vue-i18n' ||
+              name === 'vue-i18n-bridge' ||
+              name === 'petite-vue-i18n'
+            ) {
+              const outfile = `dist/${stub}`.replace(
+                'esm-bundler.js',
+                'node.mjs'
+              )
               await fs.writeFile(
                 resolve(outfile),
                 `global.__VUE_PROD_DEVTOOLS__ = false;\n` + contents
               )
               console.log(`created stub ${pc.bold(outfile)}`)
-            } else if(name === 'core') {
-              const outfile = `dist/${stub}`.replace('esm-bundler.js', 'node.mjs')
+            } else if (name === 'core') {
+              const outfile = `dist/${stub}`.replace(
+                'esm-bundler.js',
+                'node.mjs'
+              )
               await fs.writeFile(
                 resolve(outfile),
-                `global.__VUE_PROD_DEVTOOLS__ = false;\nglobal.__INTLIFY_JIT_COMPILATION__ = true;\n` + contents
+                `global.__VUE_PROD_DEVTOOLS__ = false;\nglobal.__INTLIFY_JIT_COMPILATION__ = true;\n` +
+                  contents
               )
               console.log(`created stub ${pc.bold(outfile)}`)
             }
-          } 
+          }
         }
       }
     ],


### PR DESCRIPTION
This PR  is for #1569.
We need to support `@intlify/unplugin-vue-i18n` to fix it fully.