### PR TITLE
feat!: type-safe messages

### DIFF
--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -118,8 +118,10 @@ import { isLegacyVueI18n } from './utils'
 
 export { DEFAULT_LOCALE } from '@intlify/core-base'
 
+type LocaleMessageKey = string
+
 // extend VNode interface
-export const DEVTOOLS_META = '__INTLIFY_META__'
+export const DEVTOOLS_META:LocaleMessageKey = '__INTLIFY_META__'
 
 /** @VueI18nComposition */
 export type VueMessageType = string | ResourceNode | VNode


### PR DESCRIPTION
This PR adds type safe message translation when used with helpers such as t().

The reason it's a breaking change is because it's more strict, which could bring some edge case bugs with non-existent messages.

It is a draft for now because there is much work I need to do to get it to work.

#### Benefits:
This allows for much safer and convenient locale message translation by providing autocomplete suggestions to make sure no typos are present. Essentially a very useful DX update.