### PR TITLE
Register vue jsx types in tsx test

### DIFF
--- a/test-dts/vue-i18n/components.test-d.tsx
+++ b/test-dts/vue-i18n/components.test-d.tsx
@@ -1,3 +1,4 @@
+import 'vue/jsx'
 import { expectType, expectError } from '..'
 
 import {


### PR DESCRIPTION
In Vue 3.4, implicit global JSX type registration will be removed. Explicitly importing `vue/jsx` preserves the old behavior.