### PR TITLE
chore: improve Vue type definition appending

### DIFF
--- a/packages/petite-vue-i18n/src/vue.d.ts
+++ b/packages/petite-vue-i18n/src/vue.d.ts
@@ -30,6 +30,7 @@ import type {
 } from '../../vue-i18n-core/src/legacy'
 import type { ExportedGlobalComposer } from '../../vue-i18n-core/src/i18n'
 
+// --- THE CONTENT BELOW THIS LINE WILL BE APPENDED TO DTS FILE IN DIST DIRECTORY --- //
 declare module '@vue/runtime-core' {
   /**
    * Component Custom Options for Vue I18n
@@ -89,7 +90,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -112,7 +114,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -136,7 +139,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -162,7 +166,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -187,7 +192,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -211,7 +217,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -234,7 +241,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -257,7 +265,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -282,7 +291,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -307,7 +317,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -332,7 +343,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -357,7 +369,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -382,7 +395,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -408,7 +422,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -434,7 +449,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -459,7 +475,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -484,7 +501,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -510,7 +528,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -536,7 +555,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -631,7 +651,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -655,7 +676,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -680,7 +702,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -706,7 +729,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -732,7 +756,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -759,7 +784,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -787,7 +813,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -815,7 +842,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -840,7 +868,8 @@ declare module '@vue/runtime-core' {
      */
     $te<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -881,7 +910,8 @@ declare module '@vue/runtime-core' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedDateTimeFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
@@ -907,7 +937,8 @@ declare module '@vue/runtime-core' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedDateTimeFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
@@ -959,7 +990,8 @@ declare module '@vue/runtime-core' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedDateTimeFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
@@ -985,7 +1017,8 @@ declare module '@vue/runtime-core' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedDateTimeFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
@@ -1038,7 +1071,8 @@ declare module '@vue/runtime-core' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
@@ -1063,7 +1097,8 @@ declare module '@vue/runtime-core' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
@@ -1150,7 +1185,8 @@ declare module '@vue/runtime-core' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
@@ -1175,7 +1211,8 @@ declare module '@vue/runtime-core' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]

--- a/packages/vue-i18n-bridge/src/vue.d.ts
+++ b/packages/vue-i18n-bridge/src/vue.d.ts
@@ -35,6 +35,7 @@ import type {
   NumberFormat
 } from '../../vue-i18n-core/src/components'
 
+// --- THE CONTENT BELOW THIS LINE WILL BE APPENDED TO DTS FILE IN DIST DIRECTORY --- //
 declare module '@vue/runtime-core' {
   /**
    * Component Custom Options for Vue I18n
@@ -94,7 +95,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -117,7 +119,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -141,7 +144,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -167,7 +171,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -192,7 +197,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -216,7 +222,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -239,7 +246,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -262,7 +270,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -287,7 +296,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -312,7 +322,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -337,7 +348,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -362,7 +374,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -387,7 +400,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -413,7 +427,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -439,7 +454,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -464,7 +480,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -489,7 +506,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -515,7 +533,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -541,7 +560,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -636,7 +656,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -660,7 +681,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -685,7 +707,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -711,7 +734,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -737,7 +761,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -764,7 +789,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -792,7 +818,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -820,7 +847,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -845,7 +873,8 @@ declare module '@vue/runtime-core' {
      */
     $te<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -886,7 +915,8 @@ declare module '@vue/runtime-core' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedDateTimeFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
@@ -912,7 +942,8 @@ declare module '@vue/runtime-core' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedDateTimeFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
@@ -964,7 +995,8 @@ declare module '@vue/runtime-core' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedDateTimeFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
@@ -990,7 +1022,8 @@ declare module '@vue/runtime-core' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedDateTimeFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
@@ -1043,7 +1076,8 @@ declare module '@vue/runtime-core' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
@@ -1068,7 +1102,8 @@ declare module '@vue/runtime-core' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
@@ -1155,7 +1190,8 @@ declare module '@vue/runtime-core' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
@@ -1180,7 +1216,8 @@ declare module '@vue/runtime-core' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]

--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -35,6 +35,7 @@ import type {
   NumberFormat
 } from '../../vue-i18n-core/src/components'
 
+// --- THE CONTENT BELOW THIS LINE WILL BE APPENDED TO DTS FILE IN DIST DIRECTORY --- //
 declare module '@vue/runtime-core' {
   /**
    * Component Custom Options for Vue I18n
@@ -94,7 +95,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -117,7 +119,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -141,7 +144,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -167,7 +171,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -192,7 +197,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -216,7 +222,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -239,7 +246,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -262,7 +270,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -287,7 +296,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -312,7 +322,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -337,7 +348,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -362,7 +374,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -387,7 +400,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -413,7 +427,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -439,7 +454,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -464,7 +480,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -489,7 +506,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -515,7 +533,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -541,7 +560,8 @@ declare module '@vue/runtime-core' {
      */
     $t<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -636,7 +656,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -660,7 +681,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -685,7 +707,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -711,7 +734,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -737,7 +761,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -764,7 +789,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -792,7 +818,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -820,7 +847,8 @@ declare module '@vue/runtime-core' {
      */
     $tc<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -845,7 +873,8 @@ declare module '@vue/runtime-core' {
      */
     $te<
       Key extends string,
-      DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
         ? PickupPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
@@ -886,7 +915,8 @@ declare module '@vue/runtime-core' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedDateTimeFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
@@ -912,7 +942,8 @@ declare module '@vue/runtime-core' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedDateTimeFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
@@ -964,7 +995,8 @@ declare module '@vue/runtime-core' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedDateTimeFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
@@ -990,7 +1022,8 @@ declare module '@vue/runtime-core' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedDateTimeFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
@@ -1043,7 +1076,8 @@ declare module '@vue/runtime-core' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
@@ -1068,7 +1102,8 @@ declare module '@vue/runtime-core' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
@@ -1155,7 +1190,8 @@ declare module '@vue/runtime-core' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
@@ -1180,7 +1216,8 @@ declare module '@vue/runtime-core' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,8 +4,4 @@ set -xe
 
 pnpm build --types
 
-tail -n +37 ./packages/vue-i18n/src/vue.d.ts >> ./packages/vue-i18n/dist/vue-i18n.d.ts
-tail -n +32 ./packages/petite-vue-i18n/src/vue.d.ts >> ./packages/petite-vue-i18n/dist/petite-vue-i18n.d.ts
-tail -n +37 ./packages/vue-i18n-bridge/src/vue.d.ts >> ./packages/vue-i18n-bridge/dist/vue-i18n-bridge.d.ts
-
 node -r esbuild-register scripts/postprocess.ts

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -180,6 +180,46 @@ async function main() {
         process.exitCode = 1
       }
 
+      if (
+        ['vue-i18n', 'vue-i18n-bridge', 'pretite-vue-i18n'].includes(target)
+      ) {
+        console.log()
+        console.log(
+          pc.bold(pc.yellow(`Appending Vue type definitions for ${target}...`))
+        )
+
+        let content = ''
+
+        try {
+          content = await fs.readFile(
+            path.resolve(pkgDir, 'src/vue.d.ts'),
+            'utf-8'
+          )
+        } catch (e) {
+          console.error(
+            `Failed in opening Vue type definition file with error code: ${e.code}`
+          )
+          process.exitCode = 1
+        }
+
+        try {
+          const marker =
+            '// --- THE CONTENT BELOW THIS LINE WILL BE APPENDED TO DTS FILE IN DIST DIRECTORY --- //'
+          const data = content.slice(content.indexOf(marker) + marker.length)
+
+          await fs.appendFile(path.resolve(pkgDir, `dist/${target}.d.ts`), data)
+        } catch (e) {
+          console.error('Failed in appending Vue type definitions')
+          process.exitCode = 1
+        }
+
+        console.log(
+          pc.bold(
+            pc.green(`Appending Vue type definitions completed successfully.`)
+          )
+        )
+      }
+
       // @ts-ignore
       await rimraf(`${pkgDir}/dist/packages`)
     }


### PR DESCRIPTION
This PR is created based on [a conversation on Twitter](https://x.com/NozomuIkuta/status/1741107199001383376?s=20).

With this PR, we do no longer need to manage from which line of `<target>/src/vue.d.ts` should be appended to `<target>/dist/<target>.d.ts`. All the content below the marker string will be automatically appended.

Diffs in `vue.d.ts` files are mostly generated by Prettier.
All I did to those was to add "// --- THE CONTENT BELOW THIS LINE WILL BE APPENDED TO DTS FILE IN DIST DIRECTORY --- //" as the marker string.

---

This PR change build process, so please review carefully.