### PR TITLE
fix: lower memory usage

### DIFF
--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -9,16 +9,17 @@ export function deepCopy(src: any, des: any): void {
   }
 
   const stack = [{ src, des }]
-
   while (stack.length) {
-    // @ts-ignore
-    const { src, des } = stack.pop()
+    const { src, des } = stack.pop()!
 
     Object.keys(src).forEach(key => {
       if (isNotObjectOrIsArray(src[key]) || isNotObjectOrIsArray(des[key])) {
-        // For primitive types or null, directly copy the value
+        // replace with src[key] when:
+        // src[key] or des[key] is not an object, or
+        // src[key] or des[key] is an array
         des[key] = src[key]
       } else {
+        // src[key] and des[key] are both objects, merge them
         stack.push({ src: src[key], des: des[key] })
       }
     })

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -1,4 +1,4 @@
-import { hasOwn, isArray, isObject } from './utils'
+import { isArray, isObject } from './utils'
 
 const isNotObjectOrIsArray = (val: unknown) => !isObject(val) || isArray(val)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
@@ -8,17 +8,19 @@ export function deepCopy(src: any, des: any): void {
     throw new Error('Invalid value')
   }
 
-  for (const key in src) {
-    if (hasOwn(src, key)) {
+  const stack = [{ src, des }]
+
+  while (stack.length) {
+    // @ts-ignore
+    const { src, des } = stack.pop()
+
+    Object.keys(src).forEach(key => {
       if (isNotObjectOrIsArray(src[key]) || isNotObjectOrIsArray(des[key])) {
-        // replace with src[key] when:
-        // src[key] or des[key] is not an object, or
-        // src[key] or des[key] is an array
+        // For primitive types or null, directly copy the value
         des[key] = src[key]
       } else {
-        // src[key] and des[key] are both objects, merge them
-        deepCopy(src[key], des[key])
+        stack.push({ src: src[key], des: des[key] })
       }
-    }
+    })
   }
 }

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ref, computed, getCurrentInstance, watch } from 'vue'
+import { ref, computed, getCurrentInstance, watch, shallowRef } from 'vue'
 import {
   warn,
   isArray,
@@ -1884,7 +1884,7 @@ export function createComposer(options: any = {}, VueI18nLegacy?: any): any {
         : _locale.value
   )
 
-  const _messages = ref<LocaleMessages<LocaleMessage<Message>>>(
+  const _messages = (inBrowser ? ref : shallowRef)(
     getLocaleMessages<LocaleMessages<LocaleMessage<Message>>>(
       _locale.value as Locale,
       options

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -1858,12 +1858,13 @@ export function createComposer(options: any = {}, VueI18nLegacy?: any): any {
   >
   const _isGlobal = __root === undefined
   const flatJson = options.flatJson
+  const _ref = inBrowser ? ref : shallowRef
 
   let _inheritLocale = isBoolean(options.inheritLocale)
     ? options.inheritLocale
     : true
 
-  const _locale = ref<Locale>(
+  const _locale = _ref<Locale>(
     // prettier-ignore
     __root && _inheritLocale
       ? __root.locale.value
@@ -1872,7 +1873,7 @@ export function createComposer(options: any = {}, VueI18nLegacy?: any): any {
         : DEFAULT_LOCALE
   )
 
-  const _fallbackLocale = ref<FallbackLocale>(
+  const _fallbackLocale = _ref<FallbackLocale>(
     // prettier-ignore
     __root && _inheritLocale
       ? __root.fallbackLocale.value
@@ -1884,7 +1885,7 @@ export function createComposer(options: any = {}, VueI18nLegacy?: any): any {
         : _locale.value
   )
 
-  const _messages = (inBrowser ? ref : shallowRef)(
+  const _messages = _ref(
     getLocaleMessages<LocaleMessages<LocaleMessage<Message>>>(
       _locale.value as Locale,
       options
@@ -1893,7 +1894,7 @@ export function createComposer(options: any = {}, VueI18nLegacy?: any): any {
 
   // prettier-ignore
   const _datetimeFormats = !__LITE__
-    ? ref<DateTimeFormatsType>(
+    ? _ref<DateTimeFormatsType>(
         isPlainObject(options.datetimeFormats)
           ? options.datetimeFormats
           : { [_locale.value]: {} }
@@ -1902,12 +1903,12 @@ export function createComposer(options: any = {}, VueI18nLegacy?: any): any {
 
   // prettier-ignore
   const _numberFormats = !__LITE__
-    ? ref<NumberFormatsType>(
+    ? _ref<NumberFormatsType>(
         isPlainObject(options.numberFormats)
           ? options.numberFormats
           : { [_locale.value]: {} }
       )
-    : /* #__PURE__*/ ref<NumberFormatsType>({})
+    : /* #__PURE__*/ _ref<NumberFormatsType>({})
 
   // warning suppress options
   // prettier-ignore


### PR DESCRIPTION
Not sure if there are downsides to using `shallowRef` instead of `ref` only on the server-side. As I understand it there's no reactivity on the server-side, so this shouldn't change much, besides not setting up reactivity tracking for nested keys?

In my testing this fixes the messages from leaking when using computed translations after an async function in Nuxt. I can only guess that the reason for it is that the computed translation is referencing a key inside the object preventing it from being disposed. I don't think this fixes the root cause of the leak in `@nuxtjs/i18n`, but maybe lowers memory usage overall.

I have also changed the `deepCopy` function to use iteration instead of recursion, which should lower memory usage as well.

I have tested this with https://github.com/danielroe/i18n-memory-leak with the latest `@nuxtjs/i18n` and using dependency overrides for `vue-i18n` and `vue-i18n-core` with pnpm. I also used a modified locale file to also test nested keys ([en.json](https://github.com/intlify/vue-i18n-next/files/13844192/en.json)). Unfortunately I wasn't able to run the e2e tests locally in WSL, I may have better luck on macos but haven't tried yet.

Related
* https://github.com/nuxt-modules/i18n/issues/2629
* https://github.com/intlify/vue-i18n-next/pull/1675