### PR TITLE
docs: update description of Nuxt I18n and its status

### DIFF
--- a/docs/.ja/ecosystem/tools.md
+++ b/docs/.ja/ecosystem/tools.md
@@ -1,12 +1,12 @@
 # Third-party tooling
 
-## Nuxt Module
+## Nuxt I18n Module
 
-[nuxt-i18n](https://github.com/nuxt-community/nuxt-i18n/) is corresponding Nuxt.js module.
+[Nuxt I18n (@nuxtjs/i18n)](https://github.com/nuxt-modules/i18n/) fully integrates Vue I18n for Nuxt 3 (v8 and higher). 
 
-:::warning NOTICE
-Still not supported.
-:::
+The module adds features such as localized routing, SEO tags and more.
+
+Read more about Nuxt I18n in the docs at [i18n.nuxtjs.org](https://i18n.nuxtjs.org/)
 
 ## BabelEdit
 

--- a/docs/guide/integrations/nuxt3.md
+++ b/docs/guide/integrations/nuxt3.md
@@ -1,19 +1,14 @@
 # Nuxt 3 integration
 
-We will introduce Vue I18n integration with Nuxt 3.
+We recommend using [Nuxt I18n (@nuxtjs/i18n)](https://i18n.nuxtjs.org/) to use Vue I18n with Nuxt 3 with advanced features such as localized routing, SEO tags and more.
 
-The following is a tutorial on setting up a Nuxt 3 application from the initial configuration.
+## Creating your own Nuxt 3 integration
+
+The following is a tutorial on setting up a Nuxt 3 application with your own integration by adding Vue I18n through a Nuxt plugin.
 
 :::warning NOTICE
-This Nuxt3 application is set up in this tutorial doesn't support advanced i18n, such as URL (routing), SEO with `head` tag, and `lang` attribute in `html`tag.
-
-Support for Nuxt 3 & Nuxt Bridge in [nuxtjs/i18n](https://i18n.nuxtjs.org/) is currently under development with Nuxt community.
-You can check out the status of development and docs at [v8.i18n.nuxtjs.org](https://v8.i18n.nuxtjs.org/)
-
-See the GitHub Discussion [here](https://github.com/nuxt-community/i18n-module/discussions/1287)
+This integration tutorial doesn't support advanced i18n features (such routing and SEO tags) and is intended for demonstration purposes, consider using the Nuxt I18n module check out its docs at [i18n.nuxtjs.org](https://i18n.nuxtjs.org/) for more details.
 :::
-
-If you go through this tutorial, you can learn how to integrate Vue I18n with Nuxt plugin.
 
 ## Requirements
 


### PR DESCRIPTION
I noticed the docs still refer to Nuxt I18n as not being ready yet for Nuxt 3, hopefully this prevents some confusion about the module status.