### PR TITLE
fix: manually add triple slash directive to `message-compiler`

### DIFF
--- a/packages/message-compiler/src/generator.ts
+++ b/packages/message-compiler/src/generator.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference types="source-map-js" />
 import { isString, join } from '@intlify/shared'
 import { SourceMapGenerator } from 'source-map-js'
 import { NodeTypes } from './nodes'


### PR DESCRIPTION
Resolves #1760 (tested locally using the provided reproduction)

Not sure if this would cause other issues, I haven't tested this in more projects.

After spending some time trying to figure out _why_ the triple slash directive is being added, I gave up. The actual problem in #1760 is the path inside the directive, so after adding one manually I found out that this removes the directive from the build (huh?).

