### PR TITLE
fix: number and date format components not using `scope` prop

### DIFF
--- a/packages/vue-i18n-core/src/components/DatetimeFormat.ts
+++ b/packages/vue-i18n-core/src/components/DatetimeFormat.ts
@@ -44,7 +44,7 @@ export const DatetimeFormatImpl = /* #__PURE__*/ defineComponent({
     const i18n =
       props.i18n ||
       (useI18n({
-        useScope: 'parent',
+        useScope: props.scope as 'global' | 'parent',
         __useComponent: true
       }) as unknown as Composer & ComposerInternal)
 

--- a/packages/vue-i18n-core/src/components/NumberFormat.ts
+++ b/packages/vue-i18n-core/src/components/NumberFormat.ts
@@ -43,7 +43,7 @@ export const NumberFormatImpl = /*#__PURE__*/ defineComponent({
     const i18n =
       props.i18n ||
       (useI18n({
-        useScope: 'parent',
+        useScope: props.scope as 'global' | 'parent',
         __useComponent: true
       }) as unknown as Composer & ComposerInternal)
 


### PR DESCRIPTION
Related downstream https://github.com/nuxt-modules/i18n/issues/2895
Resolves https://github.com/intlify/vue-i18n-next/issues/1331


It looks like the `scope` prop is not being used by the `<i18n-n>` and `<i18n-d>` components, this should make this prop work the same way as it does for the `<i18n-t>` component while still using `'parent'` as default value.

I tested this locally using the Nuxt i18n playground (if formatting worked and no warning logged), let me know if tests need to be added!