### PR TITLE
docs: add favicon

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitepress'
 import type { HeadConfig } from 'vitepress'
 
-const head: HeadConfig[] = []
+const head: HeadConfig[] = [['link', { rel: 'icon', href: '/vue-i18n-logo.png' }]]
 
 export default defineConfig({
   title: 'Vue I18n',


### PR DESCRIPTION
Noticed there's no favicon configured, this only uses the existing `.png` icon file as there's no `.ico` variant of this, this should work fine but I could generate an `.ico` file if preferred.

This should make it a bit easier to find Vue I18n with lots of tabs opened 😅