### PR TITLE
breaking: drop fully `formatter` option codes on Legacy API

### DIFF
--- a/docs/.ja/guide/advanced/composition.md
+++ b/docs/.ja/guide/advanced/composition.md
@@ -508,7 +508,6 @@ Below is the mapping table:
 | `datetimeFormats` | `datetimeFormats` |
 | `numberFormats` | `numberFormats` |
 | `modifiers` | `modifiers` |
-| `formatter` | N/A |
 | `missing` | `getMissingHandler` / `setMissingHandler` |
 | `postTranslation` | `getPostTranslationHandler` / `setPostTranslationHandler`|
 | `silentTranslationWarn` | `missingWarn` |

--- a/docs/guide/advanced/composition.md
+++ b/docs/guide/advanced/composition.md
@@ -477,7 +477,6 @@ Below is the mapping table:
 | `datetimeFormats` | `datetimeFormats` |
 | `numberFormats` | `numberFormats` |
 | `modifiers` | `modifiers` |
-| `formatter` | N/A |
 | `missing` | `getMissingHandler` / `setMissingHandler` |
 | `postTranslation` | `getPostTranslationHandler` / `setPostTranslationHandler`|
 | `silentTranslationWarn` | `missingWarn` |

--- a/docs/guide/migration/breaking.md
+++ b/docs/guide/migration/breaking.md
@@ -306,6 +306,10 @@ console.log(VueI18n.availability)
 
 **Reason**: Due to hard to provide custom formats in the new compiler and runtime APIs. We are planning to support it in the next major version to support in these APIs. If you would like to use ICU message format, you can use the [@formatjs/vue-intl](https://formatjs.io/docs/vue-intl/)
 
+> [!CAUTION]
+> `formatter` option implementation code is be going to fully remove in v10.
+> As an alternative, vue-i18n has the [custome message format](../advanced/format.md) as an experimental feature.
+
 ### Remove `preserveDirectiveContent` option
 
 The `v-t` directive for Vue 3 now preserves the default content. Therefore, this option and its properties have been removed from the VueI18n instance.

--- a/packages/petite-vue-i18n/src/index.ts
+++ b/packages/petite-vue-i18n/src/index.ts
@@ -81,7 +81,6 @@ export {
   WarnHtmlInMessageLevel,
   DateTimeFormatResult,
   NumberFormatResult,
-  Formatter,
   VueI18nOptions,
   VueI18n,
   VueI18nTranslation,

--- a/packages/petite-vue-i18n/src/runtime.ts
+++ b/packages/petite-vue-i18n/src/runtime.ts
@@ -73,7 +73,6 @@ export {
   WarnHtmlInMessageLevel,
   DateTimeFormatResult,
   NumberFormatResult,
-  Formatter,
   VueI18nOptions,
   VueI18n,
   VueI18nTranslation,

--- a/packages/vue-i18n-core/src/index.ts
+++ b/packages/vue-i18n-core/src/index.ts
@@ -63,7 +63,6 @@ export {
   WarnHtmlInMessageLevel,
   DateTimeFormatResult,
   NumberFormatResult,
-  Formatter,
   VueI18nOptions,
   VueI18n,
   VueI18nTranslation,

--- a/packages/vue-i18n-core/src/legacy.ts
+++ b/packages/vue-i18n-core/src/legacy.ts
@@ -76,9 +76,6 @@ export type WarnHtmlInMessageLevel = 'off' | 'warn' | 'error'
 export type DateTimeFormatResult = string
 /** @VueI18nLegacy */
 export type NumberFormatResult = string
-export interface Formatter {
-  interpolate(message: string, values: any, path: string): Array<any> | null
-}
 export type VueI18nExtender = (vueI18n: VueI18n) => Disposer | undefined
 
 /**
@@ -181,13 +178,6 @@ export interface VueI18nOptions<
    * @VueI18nSee [Custom Modifiers](../guide/essentials/syntax#custom-modifiers)
    */
   modifiers?: Options['modifiers']
-  /**
-   * @remarks
-   * The formatter that implemented with Formatter interface.
-   *
-   * @deprecated See the [here](../guide/migration/breaking#remove-custom-formatter)
-   */
-  formatter?: Formatter
   /**
    * @remarks
    * A handler for localization missing.
@@ -970,13 +960,6 @@ export interface VueI18n<
   readonly modifiers: Composition['modifiers']
   /**
    * @remarks
-   * The formatter that implemented with Formatter interface.
-   *
-   * @deprecated See the [here](../guide/migration/breaking#remove-custom-formatter)
-   */
-  formatter: Formatter
-  /**
-   * @remarks
    * A handler for localization missing.
    */
   missing: MissingHandler | null
@@ -1349,10 +1332,6 @@ function convertComposerOptions<
   const escapeParameter = !!options.escapeParameterHtml
   const inheritLocale = isBoolean(options.sync) ? options.sync : true
 
-  if (__DEV__ && options.formatter) {
-    warn(getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_FORMATTER))
-  }
-
   if (__DEV__ && options.preserveDirectiveContent) {
     warn(getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_PRESERVE_DIRECTIVE))
   }
@@ -1510,20 +1489,6 @@ export function createVueI18n(options: any = {}): any {
     // availableLocales
     get availableLocales(): Locale[] {
       return composer.availableLocales as Locale[]
-    },
-
-    // formatter
-    get formatter(): Formatter {
-      __DEV__ && warn(getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_FORMATTER))
-      // dummy
-      return {
-        interpolate() {
-          return []
-        }
-      }
-    },
-    set formatter(val: Formatter) {
-      __DEV__ && warn(getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_FORMATTER))
     },
 
     // missing

--- a/packages/vue-i18n-core/src/warnings.ts
+++ b/packages/vue-i18n-core/src/warnings.ts
@@ -7,13 +7,12 @@ const inc = incrementer(code)
 export const I18nWarnCodes = {
   FALLBACK_TO_ROOT: code, // 8
   NOT_SUPPORTED_PRESERVE: inc(), // 9
-  NOT_SUPPORTED_FORMATTER: inc(), // 10
-  NOT_SUPPORTED_PRESERVE_DIRECTIVE: inc(), // 11
-  NOT_SUPPORTED_GET_CHOICE_INDEX: inc(), // 12
-  COMPONENT_NAME_LEGACY_COMPATIBLE: inc(), // 13
-  NOT_FOUND_PARENT_SCOPE: inc(), // 14
-  IGNORE_OBJ_FLATTEN: inc(), // 15
-  NOTICE_DROP_TRANSLATE_EXIST_COMPATIBLE_FLAG: inc() // 16
+  NOT_SUPPORTED_PRESERVE_DIRECTIVE: inc(), // 10
+  NOT_SUPPORTED_GET_CHOICE_INDEX: inc(), // 11
+  COMPONENT_NAME_LEGACY_COMPATIBLE: inc(), // 12
+  NOT_FOUND_PARENT_SCOPE: inc(), // 13
+  IGNORE_OBJ_FLATTEN: inc(), // 14
+  NOTICE_DROP_TRANSLATE_EXIST_COMPATIBLE_FLAG: inc() // 15
 } as const
 
 type I18nWarnCodes = (typeof I18nWarnCodes)[keyof typeof I18nWarnCodes]
@@ -21,7 +20,6 @@ type I18nWarnCodes = (typeof I18nWarnCodes)[keyof typeof I18nWarnCodes]
 export const warnMessages: { [code: number]: string } = {
   [I18nWarnCodes.FALLBACK_TO_ROOT]: `Fall back to {type} '{key}' with root locale.`,
   [I18nWarnCodes.NOT_SUPPORTED_PRESERVE]: `Not supported 'preserve'.`,
-  [I18nWarnCodes.NOT_SUPPORTED_FORMATTER]: `Not supported 'formatter'.`,
   [I18nWarnCodes.NOT_SUPPORTED_PRESERVE_DIRECTIVE]: `Not supported 'preserveDirectiveContent'.`,
   [I18nWarnCodes.NOT_SUPPORTED_GET_CHOICE_INDEX]: `Not supported 'getChoiceIndex'.`,
   [I18nWarnCodes.COMPONENT_NAME_LEGACY_COMPATIBLE]: `Component name legacy compatible: '{name}' -> 'i18n'`,

--- a/packages/vue-i18n-core/test/legacy.test.ts
+++ b/packages/vue-i18n-core/test/legacy.test.ts
@@ -57,36 +57,6 @@ test('availableLocales', () => {
   expect(i18n.availableLocales).toEqual(['en', 'ja', 'ru', 'fr'].sort())
 })
 
-test('formatter', () => {
-  const mockWarn = vi.spyOn(shared, 'warn')
-  mockWarn.mockImplementation(() => {})
-
-  const i18n = createVueI18n({
-    formatter: {
-      interpolate() {
-        return []
-      }
-    }
-  })
-
-  expect(i18n.formatter).not.toBeUndefined()
-  i18n.formatter = {
-    interpolate() {
-      return []
-    }
-  }
-  expect(mockWarn).toHaveBeenCalledTimes(3)
-  expect(mockWarn.mock.calls[0][0]).toEqual(
-    getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_FORMATTER)
-  )
-  expect(mockWarn.mock.calls[1][0]).toEqual(
-    getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_FORMATTER)
-  )
-  expect(mockWarn.mock.calls[2][0]).toEqual(
-    getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_FORMATTER)
-  )
-})
-
 test('missing', () => {
   const i18n = createVueI18n()
   expect(i18n.missing).toEqual(null)

--- a/packages/vue-i18n/src/index.ts
+++ b/packages/vue-i18n/src/index.ts
@@ -91,7 +91,6 @@ export {
   WarnHtmlInMessageLevel,
   DateTimeFormatResult,
   NumberFormatResult,
-  Formatter,
   VueI18nOptions,
   VueI18n,
   VueI18nTranslation,

--- a/packages/vue-i18n/src/runtime.ts
+++ b/packages/vue-i18n/src/runtime.ts
@@ -83,7 +83,6 @@ export {
   WarnHtmlInMessageLevel,
   DateTimeFormatResult,
   NumberFormatResult,
-  Formatter,
   VueI18nOptions,
   VueI18n,
   VueI18nTranslation,


### PR DESCRIPTION
## breaking change
`formatter` options was deprecated in v9.
The code that has interface and warning was left in place, we remove completely in v10, as it is no longer needed.