### PR TITLE
breaking: drop fully `preserveDirectiveContent` option codes on Legacy API

### DIFF
--- a/docs/.ja/guide/advanced/composition.md
+++ b/docs/.ja/guide/advanced/composition.md
@@ -516,7 +516,6 @@ Below is the mapping table:
 | `sync` | `inheritLocale` |
 | `warnHtmlInMessage` | `warnHtmlMessage` |
 | `escapeParameterHtml` | `escapeParameter` |
-| `preserveDirectiveContent` | N/A |
 | `t` | `t` |
 | `tc` | `t` |
 | `te` | `te` |

--- a/docs/guide/advanced/composition.md
+++ b/docs/guide/advanced/composition.md
@@ -485,7 +485,6 @@ Below is the mapping table:
 | `sync` | `inheritLocale` |
 | `warnHtmlInMessage` | `warnHtmlMessage` |
 | `escapeParameterHtml` | `escapeParameter` |
-| `preserveDirectiveContent` | N/A |
 | `t` | `t` |
 | `tc` | `t` |
 | `te` | `te` |

--- a/docs/guide/migration/breaking.md
+++ b/docs/guide/migration/breaking.md
@@ -304,13 +304,17 @@ console.log(VueI18n.availability)
 
 ### Remove Custom formatter
 
-**Reason**: Due to hard to provide custom formats in the new compiler and runtime APIs. We are planning to support it in the next major version to support in these APIs. If you would like to use ICU message format, you can use the [@formatjs/vue-intl](https://formatjs.io/docs/vue-intl/)
-
 > [!CAUTION]
 > `formatter` option implementation code is be going to fully remove in v10.
 > As an alternative, vue-i18n has the [custome message format](../advanced/format.md) as an experimental feature.
 
+**Reason**: Due to hard to provide custom formats in the new compiler and runtime APIs. We are planning to support it in the next major version to support in these APIs. If you would like to use ICU message format, you can use the [@formatjs/vue-intl](https://formatjs.io/docs/vue-intl/)
+
 ### Remove `preserveDirectiveContent` option
+
+> [!CAUTION]
+> `preserveDirectiveContent` option implementation code is be going to fully remove in v10.
+> As an alternative.
 
 The `v-t` directive for Vue 3 now preserves the default content. Therefore, this option and its properties have been removed from the VueI18n instance.
 

--- a/packages/vue-i18n-core/src/legacy.ts
+++ b/packages/vue-i18n-core/src/legacy.ts
@@ -235,18 +235,6 @@ export interface VueI18nOptions<
   formatFallbackMessages?: Options['fallbackFormat']
   /**
    * @remarks
-   * Whether `v-t` directive's element should preserve `textContent` after directive is unbinded.
-   *
-   * @VueI18nSee [Custom Directive](../guide/advanced/directive)
-   * @VueI18nSee [Remove `preserveDirectiveContent` option](../guide/migration/breaking#remove-preservedirectivecontent-option)
-   *
-   * @defaultValue `false`
-   *
-   * @deprecated The `v-t` directive for Vue 3 now preserves the default content. Therefore, this option and its properties have been removed from the VueI18n instance.
-   */
-  preserveDirectiveContent?: boolean
-  /**
-   * @remarks
    * Whether to allow the use locale messages of HTML formatting.
    *
    * See the warnHtmlInMessage property.
@@ -1016,16 +1004,6 @@ export interface VueI18n<
    */
   escapeParameterHtml: Composition['escapeParameter']
   /**
-   * @remarks
-   * Whether `v-t` directive's element should preserve `textContent` after directive is unbinded.
-   *
-   * @VueI18nSee [Custom Directive](../guide/advanced/directive)
-   * @VueI18nSee [Remove preserveDirectiveContent option](../guide/migration/breaking#remove-preservedirectivecontent-option)
-   *
-   * @deprecated The `v-t` directive for Vue 3 now preserves the default content. Therefore, this option and its properties have been removed from the VueI18n instance.
-   */
-  preserveDirectiveContent: boolean
-  /**
    * A set of rules for word pluralization
    *
    * @VueI18nSee [Custom Pluralization](../guide/essentials/pluralization#custom-pluralization)
@@ -1332,10 +1310,6 @@ function convertComposerOptions<
   const escapeParameter = !!options.escapeParameterHtml
   const inheritLocale = isBoolean(options.sync) ? options.sync : true
 
-  if (__DEV__ && options.preserveDirectiveContent) {
-    warn(getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_PRESERVE_DIRECTIVE))
-  }
-
   let messages = options.messages
   if (isPlainObject(options.sharedMessages)) {
     const sharedMessages = options.sharedMessages
@@ -1562,17 +1536,6 @@ export function createVueI18n(options: any = {}): any {
     },
     set escapeParameterHtml(val: boolean) {
       composer.escapeParameter = val
-    },
-
-    // preserveDirectiveContent
-    get preserveDirectiveContent(): boolean {
-      __DEV__ &&
-        warn(getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_PRESERVE_DIRECTIVE))
-      return true
-    },
-    set preserveDirectiveContent(val: boolean) {
-      __DEV__ &&
-        warn(getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_PRESERVE_DIRECTIVE))
     },
 
     // pluralizationRules

--- a/packages/vue-i18n-core/src/warnings.ts
+++ b/packages/vue-i18n-core/src/warnings.ts
@@ -7,12 +7,11 @@ const inc = incrementer(code)
 export const I18nWarnCodes = {
   FALLBACK_TO_ROOT: code, // 8
   NOT_SUPPORTED_PRESERVE: inc(), // 9
-  NOT_SUPPORTED_PRESERVE_DIRECTIVE: inc(), // 10
-  NOT_SUPPORTED_GET_CHOICE_INDEX: inc(), // 11
-  COMPONENT_NAME_LEGACY_COMPATIBLE: inc(), // 12
-  NOT_FOUND_PARENT_SCOPE: inc(), // 13
-  IGNORE_OBJ_FLATTEN: inc(), // 14
-  NOTICE_DROP_TRANSLATE_EXIST_COMPATIBLE_FLAG: inc() // 15
+  NOT_SUPPORTED_GET_CHOICE_INDEX: inc(), // 10
+  COMPONENT_NAME_LEGACY_COMPATIBLE: inc(), // 11
+  NOT_FOUND_PARENT_SCOPE: inc(), // 12
+  IGNORE_OBJ_FLATTEN: inc(), // 13
+  NOTICE_DROP_TRANSLATE_EXIST_COMPATIBLE_FLAG: inc() // 14
 } as const
 
 type I18nWarnCodes = (typeof I18nWarnCodes)[keyof typeof I18nWarnCodes]
@@ -20,7 +19,6 @@ type I18nWarnCodes = (typeof I18nWarnCodes)[keyof typeof I18nWarnCodes]
 export const warnMessages: { [code: number]: string } = {
   [I18nWarnCodes.FALLBACK_TO_ROOT]: `Fall back to {type} '{key}' with root locale.`,
   [I18nWarnCodes.NOT_SUPPORTED_PRESERVE]: `Not supported 'preserve'.`,
-  [I18nWarnCodes.NOT_SUPPORTED_PRESERVE_DIRECTIVE]: `Not supported 'preserveDirectiveContent'.`,
   [I18nWarnCodes.NOT_SUPPORTED_GET_CHOICE_INDEX]: `Not supported 'getChoiceIndex'.`,
   [I18nWarnCodes.COMPONENT_NAME_LEGACY_COMPATIBLE]: `Component name legacy compatible: '{name}' -> 'i18n'`,
   [I18nWarnCodes.NOT_FOUND_PARENT_SCOPE]: `Not found parent scope. use the global scope.`,


### PR DESCRIPTION
## breaking change
`preserveDirectiveContent` options was deprecated in v9.
The code that has interface and warning was left in place, we remove completely in v10, as it is no longer needed.