### PR TITLE
breaking: drop fully `getChoiceIndex` on Legacy API

### DIFF
--- a/docs/.ja/guide/advanced/composition.md
+++ b/docs/.ja/guide/advanced/composition.md
@@ -531,4 +531,3 @@ Below is the mapping table:
 | `getNumberFormat` | `getNumberFormat` |
 | `setNumberFormat` | `setNumberFormat` |
 | `mergeNumberFormat` | `mergeNumberFormat` |
-| `getChoiceIndex` | N/A |

--- a/docs/guide/advanced/composition.md
+++ b/docs/guide/advanced/composition.md
@@ -500,4 +500,3 @@ Below is the mapping table:
 | `getNumberFormat` | `getNumberFormat` |
 | `setNumberFormat` | `setNumberFormat` |
 | `mergeNumberFormat` | `mergeNumberFormat` |
-| `getChoiceIndex` | N/A |

--- a/docs/guide/migration/breaking.md
+++ b/docs/guide/migration/breaking.md
@@ -149,6 +149,9 @@ Similar to *[Translation API return value](#translation-api-return-value)*, the 
 
 ### Remove `getChoiceIndex`
 
+> [!CAUTION]
+> `getChoiceIndex` option implementation code is be going to fully remove in v10.
+
 To customize the pluralization rules, Vue I18n v8.x extends `getChoiceIndex` of VueI18n class.
 
 Vue I18n v8.x:

--- a/packages/vue-i18n-core/src/legacy.ts
+++ b/packages/vue-i18n-core/src/legacy.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createComposer, DefineLocaleMessage } from './composer'
-import { I18nWarnCodes, getWarnMessage } from './warnings'
 import { createI18nError, I18nErrorCodes } from './errors'
 import { EnableEmitter, DisableEmitter } from './symbols'
 import { DEFAULT_LOCALE } from '@intlify/core-base'
@@ -12,8 +11,7 @@ import {
   isBoolean,
   isFunction,
   isRegExp,
-  assign,
-  warn
+  assign
 } from '@intlify/shared'
 
 import type {
@@ -1236,15 +1234,6 @@ export interface VueI18n<
    * @param format - A target number format
    */
   mergeNumberFormat: Composition['mergeNumberFormat']
-  /**
-   * Get choice index
-   *
-   * @remarks
-   * Get pluralization index for current pluralizing number and a given amount of choices.
-   *
-   * @deprecated Use `pluralizationRules` option instead of `getChoiceIndex`.
-   */
-  getChoiceIndex: (choice: Choice, choicesLength: number) => number
 }
 
 /**
@@ -1691,14 +1680,6 @@ export function createVueI18n(options: any = {}): any {
     // mergeNumberFormat
     mergeNumberFormat(locale: Locale, format: NumberFormat): void {
       composer.mergeNumberFormat(locale, format)
-    },
-
-    // getChoiceIndex
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    getChoiceIndex(choice: Choice, choicesLength: number): number {
-      __DEV__ &&
-        warn(getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_GET_CHOICE_INDEX))
-      return -1
     }
   }
 

--- a/packages/vue-i18n-core/src/warnings.ts
+++ b/packages/vue-i18n-core/src/warnings.ts
@@ -6,18 +6,16 @@ const inc = incrementer(code)
 
 export const I18nWarnCodes = {
   FALLBACK_TO_ROOT: code, // 8
-  NOT_SUPPORTED_GET_CHOICE_INDEX: inc(), // 9
-  COMPONENT_NAME_LEGACY_COMPATIBLE: inc(), // 10
-  NOT_FOUND_PARENT_SCOPE: inc(), // 11
-  IGNORE_OBJ_FLATTEN: inc(), // 12
-  NOTICE_DROP_TRANSLATE_EXIST_COMPATIBLE_FLAG: inc() // 13
+  COMPONENT_NAME_LEGACY_COMPATIBLE: inc(), // 9
+  NOT_FOUND_PARENT_SCOPE: inc(), // 10
+  IGNORE_OBJ_FLATTEN: inc(), // 11
+  NOTICE_DROP_TRANSLATE_EXIST_COMPATIBLE_FLAG: inc() // 12
 } as const
 
 type I18nWarnCodes = (typeof I18nWarnCodes)[keyof typeof I18nWarnCodes]
 
 export const warnMessages: { [code: number]: string } = {
   [I18nWarnCodes.FALLBACK_TO_ROOT]: `Fall back to {type} '{key}' with root locale.`,
-  [I18nWarnCodes.NOT_SUPPORTED_GET_CHOICE_INDEX]: `Not supported 'getChoiceIndex'.`,
   [I18nWarnCodes.COMPONENT_NAME_LEGACY_COMPATIBLE]: `Component name legacy compatible: '{name}' -> 'i18n'`,
   [I18nWarnCodes.NOT_FOUND_PARENT_SCOPE]: `Not found parent scope. use the global scope.`,
   [I18nWarnCodes.IGNORE_OBJ_FLATTEN]: `Ignore object flatten: '{key}' key has an string value`,

--- a/packages/vue-i18n-core/test/legacy.test.ts
+++ b/packages/vue-i18n-core/test/legacy.test.ts
@@ -567,17 +567,6 @@ test('getNumberFormat / setNumberFormat / mergeNumberFormat', () => {
   })
 })
 
-test('getChoiceIndex', () => {
-  const mockWarn = vi.spyOn(shared, 'warn')
-  mockWarn.mockImplementation(() => {})
-
-  const i18n = createVueI18n({})
-  i18n.getChoiceIndex(1, 2)
-  expect(mockWarn.mock.calls[0][0]).toEqual(
-    getWarnMessage(I18nWarnCodes.NOT_SUPPORTED_GET_CHOICE_INDEX)
-  )
-})
-
 test('warnHtmlInMessage', () => {
   const mockWarn = vi.spyOn(shared, 'warn')
   mockWarn.mockImplementation(() => {})


### PR DESCRIPTION
## breaking change
`getChoiceIndex` was deprecated in v9.
The code that has interface and warning was left in place, we remove completely in v10, as it is no longer needed.