### PR TITLE
feat!: change `$t` overloaded signature for Legacy API mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: [18.19, 20]
+        node: [18.19, 20, 22]
 
     runs-on: ${{ matrix.os }}
 
@@ -144,7 +144,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: [18.19, 20]
+        node: [18.19, 20, 22]
 
     runs-on: ${{ matrix.os }}
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -195,11 +195,15 @@ function sidebarGuide() {
       collapsible: true,
       items: [
         {
-          text: 'Breaking Changes',
+          text: 'Breaking Changes in v9',
           link: '/guide/migration/breaking'
         },
         {
-          text: 'New Features',
+          text: 'Breaking Changes in v10',
+          link: '/guide/migration/breaking10'
+        },
+        {
+          text: 'New Features in v9',
           link: '/guide/migration/features'
         },
         {

--- a/docs/api/injection.md
+++ b/docs/api/injection.md
@@ -90,6 +90,10 @@ Translation message
 
 ### $t(key, locale)
 
+:::danger NOTICE
+**This API signature is available in Legacy API mode only and is supported until v9**.
+:::
+
 Locale message translation
 
 **Signature:**
@@ -112,6 +116,10 @@ Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
 Translation message
 
 ### $t(key, locale, list)
+
+:::danger NOTICE
+**This API signature is available in Legacy API mode only and is supported until v9**.
+:::
 
 Locale message translation
 
@@ -137,6 +145,10 @@ Translation message
 
 ### $t(key, locale, named)
 
+:::danger NOTICE
+**This API signature is available in Legacy API mode only and is supported until v9**.
+:::
+
 Locale message translation
 
 **Signature:**
@@ -154,6 +166,116 @@ Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
 | key | Path | A target locale message key |
 | locale | Locale | A locale, override locale that global scope or local scope |
 | named | object | A values of named interpolation |
+
+#### Returns
+
+Translation message
+
+### $t(key, plural)
+
+Locale message translation
+
+**Signature:**
+```typescript
+$t(key: Path, plural: number): TranslateResult;
+```
+
+:::tip NOTE
+Supported for **Composition API mode only until v9. v10 or later can also be used in Legacy API mode**.
+:::
+
+**Details**
+
+Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
+
+#### Parameters
+| Parameter | Type | Description |
+| --- | --- | --- |
+| key | Path | A target locale message key |
+| plural | number | A choice number of plural |
+
+#### Returns
+
+Translation message
+
+### $t(key, plural, options)
+
+Locale message translation
+
+**Signature:**
+```typescript
+$t(key: Path, plural: number, options: TranslateOptions): TranslateResult;
+```
+
+:::tip NOTE
+Supported for **Composition API mode only until v9. v10 or later can also be used in Legacy API mode**.
+:::
+
+**Details**
+
+Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
+
+#### Parameters
+| Parameter | Type | Description |
+| --- | --- | --- |
+| key | Path | A target locale message key |
+| plural | number | A choice number of plural |
+| options | TranslateOptions | An options, see the [TranslateOptions](general#translateoptions) |
+
+#### Returns
+
+Translation message
+
+### $t(key, defaultMsg)
+
+Locale message translation
+
+**Signature:**
+```typescript
+$t(key: Path, defaultMsg: string): TranslateResult;
+```
+
+:::tip NOTE
+Supported for **Composition API mode only until v9. v10 or later can also be used in Legacy API mode**.
+:::
+
+**Details**
+
+Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
+
+#### Parameters
+| Parameter | Type | Description |
+| --- | --- | --- |
+| key | Path | A target locale message key |
+| defaultMsg | string | A default message to return if no translation was found |
+
+#### Returns
+
+Translation message
+
+### $t(key, defaultMsg, options)
+
+Locale message translation
+
+**Signature:**
+```typescript
+$t(key: Path, defaultMsg: string, options: TranslateOptions): TranslateResult;
+```
+
+:::tip NOTE
+Supported for **Composition API mode only until v9. v10 or later can also be used in Legacy API mode**.
+:::
+
+**Details**
+
+Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
+
+#### Parameters
+| Parameter | Type | Description |
+| --- | --- | --- |
+| key | Path | A target locale message key |
+| defaultMsg | string | A default message to return if no translation was found |
+| options | TranslateOptions | An options, see the [TranslateOptions](general#translateoptions) |
 
 #### Returns
 
@@ -182,196 +304,17 @@ Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
 
 Translation message
 
-### $t(key, named)
-
-Locale message translation
-
-**Signature:**
-```typescript
-$t(key: Path, named: Record<string, unknown>): TranslateResult;
-```
-
-**Details**
-
-Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
-
-#### Parameters
-| Parameter | Type | Description |
-| --- | --- | --- |
-| key | Path | A target locale message key |
-| locale | Locale | A locale, override locale that global scope or local scope |
-| named | Record&lt;string, unknown&gt; | A values of named interpolation |
-
-#### Returns
-
-Translation message
-
-### $t(key)
-
-Locale message translation
-
-**Signature:**
-```typescript
-$t(key: Path): string;
-```
-
-**Details**
-
-Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
-
-#### Parameters
-| Parameter | Type | Description |
-| --- | --- | --- |
-| key | Path | A target locale message key |
-
-#### Returns
-
-Translation message
-
-### $t(key, plural)
-
-Locale message translation
-
-**Signature:**
-```typescript
-$t(key: Path, plural: number): string;
-```
-
-:::tip NOTE
-Supported for **Composition API mode only**.
-:::
-
-**Details**
-
-Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
-
-#### Parameters
-| Parameter | Type | Description |
-| --- | --- | --- |
-| key | Path | A target locale message key |
-| plural | number | A choice number of plural |
-
-#### Returns
-
-Translation message
-
-### $t(key, plural, options)
-
-Locale message translation
-
-**Signature:**
-```typescript
-$t(key: Path, plural: number, options: TranslateOptions): string;
-```
-
-:::tip NOTE
-Supported for **Composition API mode only**.
-:::
-
-**Details**
-
-Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
-
-#### Parameters
-| Parameter | Type | Description |
-| --- | --- | --- |
-| key | Path | A target locale message key |
-| plural | number | A choice number of plural |
-| options | TranslateOptions | An options, see the [TranslateOptions](general#translateoptions) |
-
-#### Returns
-
-Translation message
-
-### $t(key, defaultMsg)
-
-Locale message translation
-
-**Signature:**
-```typescript
-$t(key: Path, defaultMsg: string): string;
-```
-
-:::tip NOTE
-Supported for **Composition API mode only**.
-:::
-
-**Details**
-
-Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
-
-#### Parameters
-| Parameter | Type | Description |
-| --- | --- | --- |
-| key | Path | A target locale message key |
-| defaultMsg | string | A default message to return if no translation was found |
-
-#### Returns
-
-Translation message
-
-### $t(key, defaultMsg, options)
-
-Locale message translation
-
-**Signature:**
-```typescript
-$t(key: Path, defaultMsg: string, options: TranslateOptions): string;
-```
-
-:::tip NOTE
-Supported for **Composition API mode only**.
-:::
-
-**Details**
-
-Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
-
-#### Parameters
-| Parameter | Type | Description |
-| --- | --- | --- |
-| key | Path | A target locale message key |
-| defaultMsg | string | A default message to return if no translation was found |
-| options | TranslateOptions | An options, see the [TranslateOptions](general#translateoptions) |
-
-#### Returns
-
-Translation message
-
-### $t(key, list)
-
-Locale message translation
-
-**Signature:**
-```typescript
-$t(key: Path, list: unknown[]): string;
-```
-
-**Details**
-
-Overloaded `$t`. About details, see the [$t](injection#t-key) remarks.
-
-#### Parameters
-| Parameter | Type | Description |
-| --- | --- | --- |
-| key | Path | A target locale message key |
-| list | unknown[] | A values of list interpolation |
-
-#### Returns
-
-Translation message
-
 ### $t(key, list, plural)
 
 Locale message translation
 
 **Signature:**
 ```typescript
-$t(key: Path, list: unknown[], plural: number): string;
+$t(key: Path, list: unknown[], plural: number): TranslateResult;
 ```
 
 :::tip NOTE
-Supported for **Composition API mode only**.
+Supported for **Composition API mode only until v9. v10 or later can also be used in Legacy API mode**.
 :::
 
 **Details**
@@ -395,11 +338,11 @@ Locale message translation
 
 **Signature:**
 ```typescript
-$t(key: Path, list: unknown[], defaultMsg: string): string;
+$t(key: Path, list: unknown[], defaultMsg: string): TranslateResult;
 ```
 
 :::tip NOTE
-Supported for **Composition API mode only**.
+Supported for **Composition API mode only until v9. v10 or later can also be used in Legacy API mode**.
 :::
 
 **Details**
@@ -423,11 +366,11 @@ Locale message translation
 
 **Signature:**
 ```typescript
-$t(key: Path, list: unknown[], options: TranslateOptions): string;
+$t(key: Path, list: unknown[], options: TranslateOptions): TranslateResult;
 ```
 
 :::tip NOTE
-Supported for **Composition API mode only**.
+Supported for **Composition API mode only until v9. v10 or later can also be used in Legacy API mode**.
 :::
 
 **Details**
@@ -451,7 +394,7 @@ Locale message translation
 
 **Signature:**
 ```typescript
-$t(key: Path, named: NamedValue): string;
+$t(key: Path, named: NamedValue): TranslateResult;
 ```
 
 **Details**
@@ -474,11 +417,11 @@ Locale message translation
 
 **Signature:**
 ```typescript
-$t(key: Path, named: NamedValue, plural: number): string;
+$t(key: Path, named: NamedValue, plural: number): TranslateResult;
 ```
 
 :::tip NOTE
-Supported for **Composition API mode only**.
+Supported for **Composition API mode only until v9. v10 or later can also be used in Legacy API mode**.
 :::
 
 **Details**
@@ -502,11 +445,11 @@ Locale message translation
 
 **Signature:**
 ```typescript
-$t(key: Path, named: NamedValue, defaultMsg: string): string;
+$t(key: Path, named: NamedValue, defaultMsg: string): TranslateResult;
 ```
 
 :::tip NOTE
-Supported for **Composition API mode only**.
+Supported for **Composition API mode only until v9. v10 or later can also be used in Legacy API mode**.
 :::
 
 **Details**
@@ -530,11 +473,11 @@ Locale message translation
 
 **Signature:**
 ```typescript
-$t(key: Path, named: NamedValue, options: TranslateOptions): string;
+$t(key: Path, named: NamedValue, options: TranslateOptions): TranslateResult;
 ```
 
 :::tip NOTE
-Supported for **Composition API mode only**.
+Supported for **Composition API mode only until v9. v10 or later can also be used in Legacy API mode**.
 :::
 
 **Details**

--- a/docs/guide/migration/breaking.md
+++ b/docs/guide/migration/breaking.md
@@ -1,4 +1,4 @@
-# Breaking Changes
+# Breaking Changes in v9
 
 Most of the APIs offered in Vue I18n v9 (for Vue 3) strive to maintain compatibility, to ease the pain of migration from v8 (for Vue 2). But there are still a few breaking changes that you might encounter while migrating your application. This guide is how to adapt your application to make it work with Vue I18n v9.
 

--- a/docs/guide/migration/breaking10.md
+++ b/docs/guide/migration/breaking10.md
@@ -1,0 +1,102 @@
+# Breaking Changes in v10
+
+:::warning NOTICE
+Vue I18n v10 **is still an alpha version**.
+:::
+
+## APIs
+
+### Change `$t` overloaded signature for Legacy API mode
+
+In Vue I18n v9, it has a different interface from the Composition API mode and Legacy API mode of the `$t` overloade signature.
+
+Especially, `$t` signature in Legacy API mode has fewer overloaded signatures than in Composition API mode, as shown below:
+
+| `$t` overloaded signatures                                                       | Legacy API v9 | Legacy API v10 | Composition API v9 & v10 |
+| -------------------------------------------------------------------------------- | ------------- | -------------- | ------------------------ |
+| `$t(key: Path): TranslateResult;`                                                | ✅            | ✅             | ✅                       |
+| `$t(key: Path, locale: Locale): TranslateResult;`                                | ✅            | -              | -                        |
+| `$t(key: Path, locale: Locale, list: unknown[]): TranslateResult;`               | ✅            | -              | -                        |
+| `$t(key: Path, locale: Locale, named: NamedValue): TranslateResult;`             | ✅            | -              | -                        |
+| `$t(key: Path, plural: number): TranslateResult;`                                | -             | ✅             | ✅                       |
+| `$t(key: Path, plural: number, options: TranslateOptions): TranslateResult;`     | -             | ✅             | ✅                       |
+| `$t(key: Path, defaultMsg: string): TranslateResult;`                            | -             | ✅             | ✅                       |
+| `$t(key: Path, defaultMsg: string, options: TranslateOptions): TranslateResult;` | -             | ✅             | ✅                       |
+| `$t(key: Path, list: unknown[]): TranslateResult;`                               | ✅            | ✅             | ✅                       |
+| `$t(key: Path, list: unknown[], plural: number): TranslateResult;`               | -             | ✅             | ✅                       |
+| `$t(key: Path, list: unknown[], defaultMsg: string): TranslateResult;`           | -             | ✅             | ✅                       |
+| `$t(key: Path, list: unknown[], options: TranslateOptions): TranslateResult;`    | -             | ✅             | ✅                       |
+| `$t(key: Path, named: Record<string, unknown>): TranslateResult;`                | ✅            | ✅             | ✅                       |
+| `$t(key: Path, named: NamedValue, plural: number): TranslateResult;`             | -             | ✅             | ✅                       |
+| `$t(key: Path, named: NamedValue, defaultMsg: string): TranslateResult;`         | -             | ✅             | ✅                       |
+| `$t(key: Path, named: NamedValue, options: TranslateOptions): TranslateResult;`  | -             | ✅             | ✅                       |
+
+Starting from v10, Legacy API mode can use the same `$t` overload signature as Composition API mode.
+
+**Reason**: After that migration, when migrating to Composition API mode, we sometimes fall into a pitfall due to the different signature of `$t`.
+
+If you are using the following APIs in Legacy API mode, you must change to another signature because of the breaking changes:
+
+- `$t(key: Path, locale: Locale): TranslateResult;`
+- `$t(key: Path, locale: Locale, list: unknown[]): TranslateResult;`
+- `$t(key: Path, locale: Locale, named: NamedValue): TranslateResult;`
+
+#### `$t(key: Path, locale: Locale): TranslateResult;`
+
+Vue I18n v9.x:
+
+```vue
+<template>
+  <p>{{ $t('message.hello', 'ja') }}</p>
+</template>
+```
+
+Vue I18n v10 or later:
+
+use `$t(key: Path, list: unknown[], options: TranslateOptions): TranslateResult;` or `$t(key: Path, named: NamedValue, options: TranslateOptions): TranslateResult;`
+
+```vue
+<template>
+  <p>{{ $t('message.hello', {}, { locale: 'ja' }) }}</p>
+</template>
+```
+
+#### `$t(key: Path, locale: Locale, list: unknown[]): TranslateResult;`
+
+Vue I18n v9.x:
+
+```vue
+<template>
+  <p>{{ $t('message.hello', 'ja', ['dio']) }}</p>
+</template>
+```
+
+Vue I18n v10 or later:
+
+use `$t(key: Path, list: unknown[], options: TranslateOptions): TranslateResult;`
+
+```vue
+<template>
+  <p>{{ $t('message.hello', ['dio'], { locale: 'ja' }) }}</p>
+</template>
+```
+
+#### `$t(key: Path, locale: Locale, named: NamedValue): TranslateResult;`
+
+Vue I18n v9.x:
+
+```vue
+<template>
+  <p>{{ $t('message.hello', 'ja', { name: 'dio' }) }}</p>
+</template>
+```
+
+Vue I18n v10 or later:
+
+use `$t(key: Path, named: NamedValue, options: TranslateOptions): TranslateResult;`
+
+```vue
+<template>
+  <p>{{ $t('message.hello', { name: 'dio' }, { locale: 'ja' }) }}</p>
+</template>
+```

--- a/docs/guide/migration/breaking10.md
+++ b/docs/guide/migration/breaking10.md
@@ -8,7 +8,7 @@ Vue I18n v10 **is still an alpha version**.
 
 ### Change `$t` overloaded signature for Legacy API mode
 
-In Vue I18n v9, it has a different interface from the Composition API mode and Legacy API mode of the `$t` overloade signature.
+In Vue I18n v9, it has a different interface from the Composition API mode and Legacy API mode of the `$t` overloaded signature.
 
 Especially, `$t` signature in Legacy API mode has fewer overloaded signatures than in Composition API mode, as shown below:
 

--- a/docs/guide/migration/features.md
+++ b/docs/guide/migration/features.md
@@ -1,4 +1,4 @@
-# New Features
+# New Features in v9
 
 Vue I18n v9 offers not only Vue 3 support, but this version also is included new features.
 

--- a/examples/legacy/components/translation.html
+++ b/examples/legacy/components/translation.html
@@ -19,7 +19,9 @@
 
       <h2>localize with DOM contents:</h2>
       <i18n-t tag="p" class="list" keypath="message.list" locale="en">
-        <span class="lang">{{ $t('message.language','en') }}</span>
+        <span class="lang"
+          >{{ $t('message.language', [], { locale: 'en' }) }}</span
+        >
       </i18n-t>
 
       <h2>localize with using linked:</h2>
@@ -31,7 +33,9 @@
 
       <h2>localize with using plural:</h2>
       <form>
-        <label for="locale-select">{{ $t('message.quantity', 'en') }}</label>
+        <label for="locale-select"
+          >{{ $t('message.quantity', {}, { locale: 'en' }) }}</label
+        >
         <select id="locale-select" v-model="count">
           <option value="0">0</option>
           <option value="1">1</option>

--- a/packages/petite-vue-i18n/src/vue.d.ts
+++ b/packages/petite-vue-i18n/src/vue.d.ts
@@ -107,157 +107,6 @@ declare module '@vue/runtime-core' {
      * @remarks
      * Overloaded `$t`. About details, see the {@link $t} remarks.
      *
-     * @param key -  A target locale message key
-     * @param locale - A locale, override locale that global scope or local scope
-     *
-     * @returns translation message
-     */
-    $t<
-      Key extends string,
-      DefinedLocaleMessage extends
-        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
-      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
-            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
-          }>
-        : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
-    >(
-      key: Key | ResourceKeys | Path
-    ): TranslateResult
-    /**
-     * Locale message translation
-     *
-     * @remarks
-     * Overloaded `$t`. About details, see the {@link $t} remarks.
-     *
-     * @param key - A target locale message key
-     * @param locale - A locale, override locale that global scope or local scope
-     * @param list - A values of list interpolation
-     *
-     * @returns translation message
-     */
-    $t<
-      Key extends string,
-      DefinedLocaleMessage extends
-        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
-      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
-            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
-          }>
-        : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
-    >(
-      key: Key | ResourceKeys | Path,
-      locale: Locale,
-      list: unknown[]
-    ): TranslateResult
-    /**
-     * Locale message translation
-     *
-     * @remarks
-     * Overloaded `$t`. About details, see the {@link $t} remarks.
-     *
-     * @param key - A target locale message key
-     * @param locale - A locale, override locale that global scope or local scope
-     * @param named - A values of named interpolation
-     *
-     * @returns translation message
-     */
-    $t<
-      Key extends string,
-      DefinedLocaleMessage extends
-        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
-      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
-            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
-          }>
-        : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
-    >(
-      key: Key | ResourceKeys | Path,
-      locale: Locale,
-      named: object
-    ): TranslateResult
-    /**
-     * Locale message translation
-     *
-     * @remarks
-     * Overloaded `$t`. About details, see the {@link $t} remarks.
-     *
-     * @param key - A target locale message key
-     * @param list - A values of list interpolation
-     *
-     * @returns translation message
-     */
-    $t<
-      Key extends string,
-      DefinedLocaleMessage extends
-        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
-      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
-            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
-          }>
-        : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
-    >(
-      key: Key | ResourceKeys | Path,
-      list: unknown[]
-    ): TranslateResult
-    /**
-     * Locale message translation
-     *
-     * @remarks
-     * Overloaded `$t`. About details, see the {@link $t} remarks.
-     *
-     * @param key - A target locale message key
-     * @param named - A values of named interpolation
-     *
-     * @returns translation message
-     */
-    $t<
-      Key extends string,
-      DefinedLocaleMessage extends
-        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
-      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
-            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
-          }>
-        : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
-    >(
-      key: Key | ResourceKeys | Path,
-      named: Record<string, unknown>
-    ): TranslateResult
-    /**
-     * Locale message translation
-     *
-     * @remarks
-     * Overloaded `$t`. About details, see the {@link $t} remarks.
-     *
-     * @param key - A target locale message key
-     *
-     * @returns translation message
-     */
-    $t<
-      Key extends string,
-      DefinedLocaleMessage extends
-        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
-      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
-            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
-          }>
-        : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
-    >(
-      key: Key | ResourceKeys | Path
-    ): string
-    /**
-     * Locale message translation
-     *
-     * @remarks
-     * Overloaded `$t`. About details, see the {@link $t} remarks.
-     *
      * @param key - A target locale message key
      * @param plural - A choice number of plural
      *
@@ -276,7 +125,7 @@ declare module '@vue/runtime-core' {
     >(
       key: Key | ResourceKeys | Path,
       plural: number
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -303,7 +152,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       plural: number,
       options: TranslateOptions
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -328,7 +177,7 @@ declare module '@vue/runtime-core' {
     >(
       key: Key | ResourceKeys | Path,
       defaultMsg: string
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -355,7 +204,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       defaultMsg: string,
       options: TranslateOptions
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -380,7 +229,7 @@ declare module '@vue/runtime-core' {
     >(
       key: Key | ResourceKeys | Path,
       list: unknown[]
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -407,7 +256,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       list: unknown[],
       plural: number
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -461,7 +310,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       list: unknown[],
       options: TranslateOptions
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -486,7 +335,7 @@ declare module '@vue/runtime-core' {
     >(
       key: Key | ResourceKeys | Path,
       named: NamedValue
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -513,7 +362,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       named: NamedValue,
       plural: number
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -540,7 +389,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       named: NamedValue,
       defaultMsg: string
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -567,7 +416,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       named: NamedValue,
       options: TranslateOptions
-    ): string
+    ): TranslateResult
     /**
      * Resolve locale message translation
      *

--- a/packages/vue-i18n-core/src/legacy.ts
+++ b/packages/vue-i18n-core/src/legacy.ts
@@ -1537,38 +1537,10 @@ export function createVueI18n(options: any = {}): any {
 
     // t
     t(...args: unknown[]): TranslateResult {
-      const [arg1, arg2, arg3] = args
-      const options = {} as TranslateOptions
-      let list: unknown[] | null = null
-      let named: NamedValue | null = null
-
-      if (!isString(arg1)) {
-        throw createI18nError(I18nErrorCodes.INVALID_ARGUMENT)
-      }
-      const key = arg1
-
-      if (isString(arg2)) {
-        options.locale = arg2
-      } else if (isArray(arg2)) {
-        list = arg2
-      } else if (isPlainObject(arg2)) {
-        named = arg2 as NamedValue
-      }
-
-      if (isArray(arg3)) {
-        list = arg3
-      } else if (isPlainObject(arg3)) {
-        named = arg3 as NamedValue
-      }
-
-      // return composer.t(key, (list || named || {}) as any, options)
-      return Reflect.apply(composer.t, composer, [
-        key,
-        (list || named || {}) as any,
-        options
-      ])
+      return Reflect.apply(composer.t, composer, [...args])
     },
 
+    // rt
     rt(...args: unknown[]): TranslateResult {
       return Reflect.apply(composer.rt, composer, [...args])
     },

--- a/packages/vue-i18n-core/test/legacy.test.ts
+++ b/packages/vue-i18n-core/test/legacy.test.ts
@@ -176,25 +176,6 @@ describe('t', () => {
     expect(i18n.t('morning', ['kazupon'])).toEqual('good morning kazupon')
     expect(i18n.t('linked')).toEqual('hi KAZUPON')
   })
-
-  test(errorMessages[I18nErrorCodes.INVALID_ARGUMENT], () => {
-    const i18n = createVueI18n({
-      locale: 'en',
-      messages: {
-        en: {
-          name: 'kazupon',
-          hello: 'Hello!',
-          hi: 'hi {name}!',
-          morning: 'good morning {0}',
-          linked: 'hi @.upper:name'
-        }
-      }
-    })
-
-    expect(() => {
-      i18n.t(4 as any) // eslint-disable-line @typescript-eslint/no-explicit-any
-    }).toThrowError(errorMessages[I18nErrorCodes.INVALID_ARGUMENT])
-  })
 })
 
 describe('rt', () => {

--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -112,157 +112,6 @@ declare module '@vue/runtime-core' {
      * @remarks
      * Overloaded `$t`. About details, see the {@link $t} remarks.
      *
-     * @param key -  A target locale message key
-     * @param locale - A locale, override locale that global scope or local scope
-     *
-     * @returns translation message
-     */
-    $t<
-      Key extends string,
-      DefinedLocaleMessage extends
-        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
-      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
-            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
-          }>
-        : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
-    >(
-      key: Key | ResourceKeys | Path
-    ): TranslateResult
-    /**
-     * Locale message translation
-     *
-     * @remarks
-     * Overloaded `$t`. About details, see the {@link $t} remarks.
-     *
-     * @param key - A target locale message key
-     * @param locale - A locale, override locale that global scope or local scope
-     * @param list - A values of list interpolation
-     *
-     * @returns translation message
-     */
-    $t<
-      Key extends string,
-      DefinedLocaleMessage extends
-        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
-      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
-            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
-          }>
-        : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
-    >(
-      key: Key | ResourceKeys | Path,
-      locale: Locale,
-      list: unknown[]
-    ): TranslateResult
-    /**
-     * Locale message translation
-     *
-     * @remarks
-     * Overloaded `$t`. About details, see the {@link $t} remarks.
-     *
-     * @param key - A target locale message key
-     * @param locale - A locale, override locale that global scope or local scope
-     * @param named - A values of named interpolation
-     *
-     * @returns translation message
-     */
-    $t<
-      Key extends string,
-      DefinedLocaleMessage extends
-        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
-      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
-            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
-          }>
-        : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
-    >(
-      key: Key | ResourceKeys | Path,
-      locale: Locale,
-      named: object
-    ): TranslateResult
-    /**
-     * Locale message translation
-     *
-     * @remarks
-     * Overloaded `$t`. About details, see the {@link $t} remarks.
-     *
-     * @param key - A target locale message key
-     * @param list - A values of list interpolation
-     *
-     * @returns translation message
-     */
-    $t<
-      Key extends string,
-      DefinedLocaleMessage extends
-        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
-      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
-            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
-          }>
-        : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
-    >(
-      key: Key | ResourceKeys | Path,
-      list: unknown[]
-    ): TranslateResult
-    /**
-     * Locale message translation
-     *
-     * @remarks
-     * Overloaded `$t`. About details, see the {@link $t} remarks.
-     *
-     * @param key - A target locale message key
-     * @param named - A values of named interpolation
-     *
-     * @returns translation message
-     */
-    $t<
-      Key extends string,
-      DefinedLocaleMessage extends
-        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
-      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
-            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
-          }>
-        : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
-    >(
-      key: Key | ResourceKeys | Path,
-      named: Record<string, unknown>
-    ): TranslateResult
-    /**
-     * Locale message translation
-     *
-     * @remarks
-     * Overloaded `$t`. About details, see the {@link $t} remarks.
-     *
-     * @param key - A target locale message key
-     *
-     * @returns translation message
-     */
-    $t<
-      Key extends string,
-      DefinedLocaleMessage extends
-        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
-      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
-            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
-          }>
-        : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
-    >(
-      key: Key | ResourceKeys | Path
-    ): string
-    /**
-     * Locale message translation
-     *
-     * @remarks
-     * Overloaded `$t`. About details, see the {@link $t} remarks.
-     *
      * @param key - A target locale message key
      * @param plural - A choice number of plural
      *
@@ -281,7 +130,7 @@ declare module '@vue/runtime-core' {
     >(
       key: Key | ResourceKeys | Path,
       plural: number
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -308,7 +157,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       plural: number,
       options: TranslateOptions
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -333,7 +182,7 @@ declare module '@vue/runtime-core' {
     >(
       key: Key | ResourceKeys | Path,
       defaultMsg: string
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -360,7 +209,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       defaultMsg: string,
       options: TranslateOptions
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -385,7 +234,7 @@ declare module '@vue/runtime-core' {
     >(
       key: Key | ResourceKeys | Path,
       list: unknown[]
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -412,7 +261,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       list: unknown[],
       plural: number
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -439,7 +288,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       list: unknown[],
       defaultMsg: string
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -466,7 +315,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       list: unknown[],
       options: TranslateOptions
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -491,7 +340,7 @@ declare module '@vue/runtime-core' {
     >(
       key: Key | ResourceKeys | Path,
       named: NamedValue
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -518,7 +367,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       named: NamedValue,
       plural: number
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -545,7 +394,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       named: NamedValue,
       defaultMsg: string
-    ): string
+    ): TranslateResult
     /**
      * Locale message translation
      *
@@ -572,7 +421,7 @@ declare module '@vue/runtime-core' {
       key: Key | ResourceKeys | Path,
       named: NamedValue,
       options: TranslateOptions
-    ): string
+    ): TranslateResult
     /**
      * Resolve locale message translation
      *


### PR DESCRIPTION
## feature (has breaking change)

In Vue I18n v9, it has a different interface from the Composition API mode and Legacy API mode of the `$t` overloaded signature.

Especially, `$t` signature in Legacy API mode has fewer overloaded signatures than in Composition API mode, as shown below:

| `$t` overloaded signatures                                                       | Legacy API v9 | Legacy API v10 | Composition API v9 & v10 |
| -------------------------------------------------------------------------------- | ------------- | -------------- | ------------------------ |
| `$t(key: Path): TranslateResult;`                                                | ✅            | ✅             | ✅                       |
| `$t(key: Path, locale: Locale): TranslateResult;`                                | ✅            | -              | -                        |
| `$t(key: Path, locale: Locale, list: unknown[]): TranslateResult;`               | ✅            | -              | -                        |
| `$t(key: Path, locale: Locale, named: NamedValue): TranslateResult;`             | ✅            | -              | -                        |
| `$t(key: Path, plural: number): TranslateResult;`                                | -             | ✅             | ✅                       |
| `$t(key: Path, plural: number, options: TranslateOptions): TranslateResult;`     | -             | ✅             | ✅                       |
| `$t(key: Path, defaultMsg: string): TranslateResult;`                            | -             | ✅             | ✅                       |
| `$t(key: Path, defaultMsg: string, options: TranslateOptions): TranslateResult;` | -             | ✅             | ✅                       |
| `$t(key: Path, list: unknown[]): TranslateResult;`                               | ✅            | ✅             | ✅                       |
| `$t(key: Path, list: unknown[], plural: number): TranslateResult;`               | -             | ✅             | ✅                       |
| `$t(key: Path, list: unknown[], defaultMsg: string): TranslateResult;`           | -             | ✅             | ✅                       |
| `$t(key: Path, list: unknown[], options: TranslateOptions): TranslateResult;`    | -             | ✅             | ✅                       |
| `$t(key: Path, named: Record<string, unknown>): TranslateResult;`                | ✅            | ✅             | ✅                       |
| `$t(key: Path, named: NamedValue, plural: number): TranslateResult;`             | -             | ✅             | ✅                       |
| `$t(key: Path, named: NamedValue, defaultMsg: string): TranslateResult;`         | -             | ✅             | ✅                       |
| `$t(key: Path, named: NamedValue, options: TranslateOptions): TranslateResult;`  | -             | ✅             | ✅                       |

Starting from v10, Legacy API mode can use the same `$t` overload signature as Composition API mode.

**Reason**: After that migration, when migrating to Composition API mode, we sometimes fall into a pitfall due to the different signature of `$t`.