### PR TITLE
docs: fix typo on vue i18n name

### DIFF
--- a/docs/guide/essentials/started.md
+++ b/docs/guide/essentials/started.md
@@ -86,7 +86,7 @@ If you're curious about what this plugin does, some of its responsibilities incl
 
 ### Single-File Components
 
-Vue I18n is most commonly used in applications built using a bundler (e.g. Vite) and [SFCs](https://vuejs.org/guide/introduction.html#single-file-components) (i.e. `.vue ` files). Most of the examples in this guide will be written in that style, but Vue Router itself doesn't require you to use build tools or SFCs.
+Vue I18n is most commonly used in applications built using a bundler (e.g. Vite) and [SFCs](https://vuejs.org/guide/introduction.html#single-file-components) (i.e. `.vue ` files). Most of the examples in this guide will be written in that style, but Vue I18n itself doesn't require you to use build tools or SFCs.
 
 For example, if you're using the _global builds_ of [Vue](https://vuejs.org/guide/quick-start.html#using-vue-from-cdn) and [Vue I18n](../installation#Direct-Download-CDN), the libraries are exposed via global objects, rather than imports:
 


### PR DESCRIPTION
Just a small fix in the _Getting Started_ section of the docs where it said "Vue Router" but I think it meant "Vue I18n" 🙂 