### PR TITLE
perf: more bundle size optimization

### DIFF
--- a/packages/core-base/src/errors.ts
+++ b/packages/core-base/src/errors.ts
@@ -1,26 +1,23 @@
-import { incrementer } from '@intlify/shared'
 import {
-  CompileErrorCodes,
-  createCompileError
+  createCompileError,
+  COMPILE_ERROR_CODES_EXTEND_POINT
 } from '@intlify/message-compiler'
 
 import type { BaseError } from '@intlify/shared'
 
 export interface CoreError extends BaseError {}
 
-const code = CompileErrorCodes.__EXTEND_POINT__
-const inc = incrementer(code)
-
 export const CoreErrorCodes = {
-  INVALID_ARGUMENT: code, // 17
-  INVALID_DATE_ARGUMENT: inc(), // 18
-  INVALID_ISO_DATE_ARGUMENT: inc(), // 19
-  NOT_SUPPORT_NON_STRING_MESSAGE: inc(), // 20
-  NOT_SUPPORT_LOCALE_PROMISE_VALUE: inc(), // 21
-  NOT_SUPPORT_LOCALE_ASYNC_FUNCTION: inc(), // 22
-  NOT_SUPPORT_LOCALE_TYPE: inc(), // 23
-  __EXTEND_POINT__: inc() // 24
+  INVALID_ARGUMENT: COMPILE_ERROR_CODES_EXTEND_POINT, // 17
+  INVALID_DATE_ARGUMENT: 18,
+  INVALID_ISO_DATE_ARGUMENT: 19,
+  NOT_SUPPORT_NON_STRING_MESSAGE: 20,
+  NOT_SUPPORT_LOCALE_PROMISE_VALUE: 21,
+  NOT_SUPPORT_LOCALE_ASYNC_FUNCTION: 22,
+  NOT_SUPPORT_LOCALE_TYPE: 23
 } as const
+
+export const CORE_ERROR_CODES_EXTEND_POINT = 24
 
 export type CoreErrorCodes =
   (typeof CoreErrorCodes)[keyof typeof CoreErrorCodes]

--- a/packages/core-base/src/index.ts
+++ b/packages/core-base/src/index.ts
@@ -14,8 +14,17 @@ export * from './compilation'
 export * from './translate'
 export * from './datetime'
 export * from './number'
-export { getWarnMessage, CoreWarnCodes } from './warnings'
-export { CoreError, CoreErrorCodes, createCoreError } from './errors'
+export {
+  getWarnMessage,
+  CoreWarnCodes,
+  CORE_WARN_CODES_EXTEND_POINT
+} from './warnings'
+export {
+  CoreError,
+  CoreErrorCodes,
+  createCoreError,
+  CORE_ERROR_CODES_EXTEND_POINT
+} from './errors'
 export * from './types'
 export * from './devtools'
 

--- a/packages/core-base/src/warnings.ts
+++ b/packages/core-base/src/warnings.ts
@@ -1,18 +1,16 @@
-import { format, incrementer } from '@intlify/shared'
-
-const code = 1
-const inc = incrementer(code)
+import { format } from '@intlify/shared'
 
 export const CoreWarnCodes = {
-  NOT_FOUND_KEY: code, // 1
-  FALLBACK_TO_TRANSLATE: inc(), // 2
-  CANNOT_FORMAT_NUMBER: inc(), // 3
-  FALLBACK_TO_NUMBER_FORMAT: inc(), // 4
-  CANNOT_FORMAT_DATE: inc(), // 5
-  FALLBACK_TO_DATE_FORMAT: inc(), // 6
-  EXPERIMENTAL_CUSTOM_MESSAGE_COMPILER: inc(), // 7
-  __EXTEND_POINT__: inc() // 8
+  NOT_FOUND_KEY: 1,
+  FALLBACK_TO_TRANSLATE: 2,
+  CANNOT_FORMAT_NUMBER: 3,
+  FALLBACK_TO_NUMBER_FORMAT: 4,
+  CANNOT_FORMAT_DATE: 5,
+  FALLBACK_TO_DATE_FORMAT: 6,
+  EXPERIMENTAL_CUSTOM_MESSAGE_COMPILER: 7
 } as const
+
+export const CORE_WARN_CODES_EXTEND_POINT = 8
 
 export type CoreWarnCodes = (typeof CoreWarnCodes)[keyof typeof CoreWarnCodes]
 

--- a/packages/core-base/test/errors.test.ts
+++ b/packages/core-base/test/errors.test.ts
@@ -1,5 +1,5 @@
-import { CoreErrorCodes } from '../src/errors'
+import { CORE_ERROR_CODES_EXTEND_POINT } from '../src/errors'
 
 test('CoreErrorCodes', () => {
-  expect(CoreErrorCodes.__EXTEND_POINT__).toBe(24)
+  expect(CORE_ERROR_CODES_EXTEND_POINT).toBe(24)
 })

--- a/packages/core-base/test/warnings.test.ts
+++ b/packages/core-base/test/warnings.test.ts
@@ -1,5 +1,5 @@
-import { CoreWarnCodes } from '../src/warnings'
+import { CORE_WARN_CODES_EXTEND_POINT } from '../src/warnings'
 
 test('CoreWarnCodes', () => {
-  expect(CoreWarnCodes.__EXTEND_POINT__).toBe(8)
+  expect(CORE_WARN_CODES_EXTEND_POINT).toBe(8)
 })

--- a/packages/message-compiler/package.json
+++ b/packages/message-compiler/package.json
@@ -53,6 +53,7 @@
   "exports": {
     ".": {
       "types": "./dist/message-compiler.d.ts",
+      "import": "./dist/message-compiler.mjs",
       "browser": "./dist/message-compiler.esm-browser.js",
       "node": {
         "import": {
@@ -65,8 +66,7 @@
           "development": "./dist/message-compiler.cjs",
           "default": "./index.js"
         }
-      },
-      "import": "./dist/message-compiler.mjs"
+      }
     },
     "./dist/*": "./dist/*",
     "./package.json": "./package.json"

--- a/packages/message-compiler/src/errors.ts
+++ b/packages/message-compiler/src/errors.ts
@@ -34,24 +34,21 @@ export const CompileErrorCodes = {
   EMPTY_PLACEHOLDER: 8,
   NOT_ALLOW_NEST_PLACEHOLDER: 9,
   INVALID_LINKED_FORMAT: 10,
-
   // parser error codes
   MUST_HAVE_MESSAGES_IN_PLURAL: 11,
   UNEXPECTED_EMPTY_LINKED_MODIFIER: 12,
   UNEXPECTED_EMPTY_LINKED_KEY: 13,
   UNEXPECTED_LEXICAL_ANALYSIS: 14,
-
   // generator error codes
   UNHANDLED_CODEGEN_NODE_TYPE: 15,
-
   // minifier error codes
-  UNHANDLED_MINIFIER_NODE_TYPE: 16,
-
-  // Special value for higher-order compilers to pick up the last code
-  // to avoid collision of error codes. This should always be kept as the last
-  // item.
-  __EXTEND_POINT__: 17
+  UNHANDLED_MINIFIER_NODE_TYPE: 16
 } as const
+
+// Special value for higher-order compilers to pick up the last code
+// to avoid collision of error codes.
+// This should always be kept as the last item.
+export const COMPILE_ERROR_CODES_EXTEND_POINT = 17
 
 export type CompileErrorCodes =
   (typeof CompileErrorCodes)[keyof typeof CompileErrorCodes]

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -202,8 +202,3 @@ export function generateCodeFrame(
   }
   return res.join('\n')
 }
-
-export function incrementer(code: number): () => number {
-  let current = code
-  return () => ++current
-}

--- a/packages/shared/test/utils.test.ts
+++ b/packages/shared/test/utils.test.ts
@@ -1,10 +1,4 @@
-import {
-  format,
-  generateCodeFrame,
-  makeSymbol,
-  join,
-  incrementer
-} from '../src/index'
+import { format, generateCodeFrame, makeSymbol, join } from '../src/index'
 
 test('format', () => {
   expect(format(`foo: {0}`, 'x')).toEqual('foo: x')
@@ -59,14 +53,4 @@ test('join', () => {
     'z'
   ]
   expect(join(longSize, ' ')).toEqual(longSize.join(' '))
-})
-
-test('incrementer', () => {
-  const inc1 = incrementer(1)
-  const inc2 = incrementer(2)
-
-  expect(inc1()).toBe(2)
-  expect(inc1()).toBe(3)
-  expect(inc2()).toBe(3)
-  expect(inc2()).toBe(4)
 })

--- a/packages/vue-i18n-core/src/errors.ts
+++ b/packages/vue-i18n-core/src/errors.ts
@@ -1,35 +1,32 @@
-import { incrementer } from '@intlify/shared'
-import { CoreErrorCodes, createCompileError } from '@intlify/core-base'
+import {
+  createCompileError,
+  CORE_ERROR_CODES_EXTEND_POINT
+} from '@intlify/core-base'
 
 import type { BaseError } from '@intlify/shared'
 
 export interface I18nError extends BaseError {}
 
-const code = CoreErrorCodes.__EXTEND_POINT__
-const inc = incrementer(code)
-
 export const I18nErrorCodes = {
   // composer module errors
-  UNEXPECTED_RETURN_TYPE: code, // 24
+  UNEXPECTED_RETURN_TYPE: CORE_ERROR_CODES_EXTEND_POINT, // 24
   // legacy module errors
-  INVALID_ARGUMENT: inc(), // 25
+  INVALID_ARGUMENT: 25,
   // i18n module errors
-  MUST_BE_CALL_SETUP_TOP: inc(), // 26
-  NOT_INSTALLED: inc(), // 27
+  MUST_BE_CALL_SETUP_TOP: 26,
+  NOT_INSTALLED: 27,
   // directive module errors
-  REQUIRED_VALUE: inc(), // 28
-  INVALID_VALUE: inc(), // 29
+  REQUIRED_VALUE: 28,
+  INVALID_VALUE: 29,
   // vue-devtools errors
-  CANNOT_SETUP_VUE_DEVTOOLS_PLUGIN: inc(), // 30
-  NOT_INSTALLED_WITH_PROVIDE: inc(), // 31
+  CANNOT_SETUP_VUE_DEVTOOLS_PLUGIN: 30,
+  NOT_INSTALLED_WITH_PROVIDE: 31,
   // unexpected error
-  UNEXPECTED_ERROR: inc(), // 32
+  UNEXPECTED_ERROR: 32,
   // not compatible legacy vue-i18n constructor
-  NOT_COMPATIBLE_LEGACY_VUE_I18N: inc(), // 33
+  NOT_COMPATIBLE_LEGACY_VUE_I18N: 33,
   // Not available Compostion API in Legacy API mode. Please make sure that the legacy API mode is working properly
-  NOT_AVAILABLE_COMPOSITION_IN_LEGACY: inc(), // 34
-  // for enhancement
-  __EXTEND_POINT__: inc() // 35
+  NOT_AVAILABLE_COMPOSITION_IN_LEGACY: 34
 } as const
 
 type I18nErrorCodes = (typeof I18nErrorCodes)[keyof typeof I18nErrorCodes]

--- a/packages/vue-i18n-core/src/warnings.ts
+++ b/packages/vue-i18n-core/src/warnings.ts
@@ -1,15 +1,11 @@
-import { format, incrementer } from '@intlify/shared'
-import { CoreWarnCodes } from '@intlify/core-base'
-
-const code = CoreWarnCodes.__EXTEND_POINT__
-const inc = incrementer(code)
+import { format } from '@intlify/shared'
+import { CORE_WARN_CODES_EXTEND_POINT } from '@intlify/core-base'
 
 export const I18nWarnCodes = {
-  FALLBACK_TO_ROOT: code, // 8
-  NOT_FOUND_PARENT_SCOPE: inc(), // 9
-  IGNORE_OBJ_FLATTEN: inc(), // 10
-  DEPRECATE_TC: inc(), // 11
-  __EXTEND_POINT__: inc() // 12
+  FALLBACK_TO_ROOT: CORE_WARN_CODES_EXTEND_POINT, // 8
+  NOT_FOUND_PARENT_SCOPE: 9,
+  IGNORE_OBJ_FLATTEN: 10,
+  DEPRECATE_TC: 11
 } as const
 
 type I18nWarnCodes = (typeof I18nWarnCodes)[keyof typeof I18nWarnCodes]

--- a/packages/vue-i18n-core/test/warnings.test.ts
+++ b/packages/vue-i18n-core/test/warnings.test.ts
@@ -1,5 +1,5 @@
 import { I18nWarnCodes } from '../src/warnings'
 
 test('I18nWarnCodes', () => {
-  expect(I18nWarnCodes.__EXTEND_POINT__).toBe(12)
+  expect(I18nWarnCodes.DEPRECATE_TC).toBe(11)
 })


### PR DESCRIPTION
We can reduce around 1KB

## before
<img width="452" alt="image" src="https://github.com/intlify/vue-i18n-next/assets/72989/592f5c39-299f-4c5c-824c-9d21345010c1">


## after

<img width="449" alt="image" src="https://github.com/intlify/vue-i18n-next/assets/72989/ac5a17fd-66d4-43c9-b080-84d7c99a76ff">

## sample project
https://github.com/intlify/vite-vue-i18n-starter/tree/vite5